### PR TITLE
Add new options to the build command to improve the user experience 

### DIFF
--- a/src/Commands/BuildStaticSiteCommand.php
+++ b/src/Commands/BuildStaticSiteCommand.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Commands;
 
 use Exception;
+use Hyde\Framework\Actions\CreatesDefaultDirectories;
 use LaravelZero\Framework\Commands\Command;
 use Hyde\Framework\Services\CollectionService;
 use Hyde\Framework\DocumentationPageParser;
@@ -15,27 +16,30 @@ use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
 use Hyde\Framework\Models\DocumentationPage;
+use Illuminate\Support\Facades\File;
 
 class BuildStaticSiteCommand extends Command
 {
     /**
-    * The signature of the command.
-    *
-    * @var string
-    */
+     * The signature of the command.
+     *
+     * @var string
+     */
     protected $signature = 'build 
-        {--run-dev : Run the NPM dev script after build}
-        {--run-prod : Run the NPM prod script after build}
-        {--pretty : Should the build files be prettified?}';
-        
+    {--run-dev : Run the NPM dev script after build}
+    {--run-prod : Run the NPM prod script after build}
+    {--pretty : Should the build files be prettified?}
+    {--clean : Should the output directory be emptied before building?}
+    {--force : Allow file deletions when using --clean without confirmation?}';
+
     /**
-    * The description of the command.
-    *
-    * @var string
-    */
+     * The description of the command.
+     *
+     * @var string
+     */
     protected $description = 'Build the static site';
-    
-    
+
+
     private function debug(array $output)
     {
         if ($this->getOutput()->isVeryVerbose()) {
@@ -44,28 +48,42 @@ class BuildStaticSiteCommand extends Command
             $this->newLine();
         }
     }
-    
+
     /**
-    * Execute the console command.
-    *
-    * @return int
-    * @throws Exception
-    */
+     * Execute the console command.
+     *
+     * @return int
+     * @throws Exception
+     */
     public function handle(): int
     {
         $time_start = microtime(true);
-        
+
         $this->title('Building your static site!');
-        
+
+        if ($this->option('clean')) {
+            if ($this->option('force')) {
+                $this->purge();
+            } else {
+                $this->warn('The --clean option will remove all files in the output directory before building.');
+                if ($this->confirm(' Are you sure?')) {
+                    $this->purge();
+                } else {
+                    $this->warn('Aborting.');
+                    return 1;
+                }
+            }
+        }
+
         if ($this->getOutput()->isVeryVerbose()) {
             $this->warn('Running with high verbosity');
+            $this->newLine();
         }
-        
+
         $collection = glob(Hyde::path('_media/*.{png,svg,jpg,jpeg,gif,ico}'), GLOB_BRACE);
         if (sizeof($collection) < 1) {
             $this->line('No Media Assets found. Skipping...');
-                $this->newLine();
-
+            $this->newLine();
         } else {
             $this->comment('Transferring Media Assets...');
             $this->withProgressBar(
@@ -73,14 +91,14 @@ class BuildStaticSiteCommand extends Command
                 function ($filepath) {
                     if ($this->getOutput()->isVeryVerbose()) {
                         $this->line(' > Copying media file '
-                        . basename($filepath). ' to the output media directory');
+                            . basename($filepath) . ' to the output media directory');
                     }
-                    copy($filepath, Hyde::path('_site/media/'. basename($filepath)));
+                    copy($filepath, Hyde::path('_site/media/' . basename($filepath)));
                 }
             );
             $this->newLine(2);
         }
-        
+
         if (Features::hasBlogPosts()) {
             $collection = CollectionService::getSourceSlugsOfModels(MarkdownPost::class);
             if (sizeof($collection) < 1) {
@@ -92,13 +110,13 @@ class BuildStaticSiteCommand extends Command
                     $collection,
                     function ($slug) {
                         $this->debug((new StaticPageBuilder((new MarkdownPostParser($slug))->get(), true))
-                        ->getDebugOutput());
+                            ->getDebugOutput());
                     }
                 );
                 $this->newLine(2);
             }
         }
-        
+
         if (Features::hasMarkdownPages()) {
             $collection = CollectionService::getSourceSlugsOfModels(MarkdownPage::class);
             if (sizeof($collection) < 1) {
@@ -116,15 +134,15 @@ class BuildStaticSiteCommand extends Command
                 $this->newLine(2);
             }
         }
-            
+
         if (Features::hasDocumentationPages()) {
             $collection = CollectionService::getSourceSlugsOfModels(DocumentationPage::class);
-            
+
             if (sizeof($collection) < 1) {
                 $this->line('No Documentation Pages found. Skipping...');
                 $this->newLine();
             } else {
-            $this->comment('Creating Documentation Pages...');
+                $this->comment('Creating Documentation Pages...');
                 $this->withProgressBar(
                     $collection,
                     function ($slug) {
@@ -135,15 +153,15 @@ class BuildStaticSiteCommand extends Command
                 $this->newLine(2);
             }
         }
-        
+
         if (Features::hasBladePages()) {
             $collection = CollectionService::getSourceSlugsOfModels(BladePage::class);
-            
+
             if (sizeof($collection) < 1) {
                 $this->line('No Blade Pages found. Skipping...');
                 $this->newLine();
             } else {
-            $this->comment('Creating Custom Blade Pages...');
+                $this->comment('Creating Custom Blade Pages...');
                 $this->withProgressBar(
                     $collection,
                     function ($slug) {
@@ -154,8 +172,8 @@ class BuildStaticSiteCommand extends Command
                 $this->newLine(2);
             }
         }
-        
-        
+
+
         if ($this->option('pretty')) {
             $this->info('Prettifying code! This may take a second.');
             try {
@@ -164,7 +182,7 @@ class BuildStaticSiteCommand extends Command
                 $this->warn('Could not prettify code! Is NPM installed?');
             }
         }
-        
+
         if ($this->option('run-dev')) {
             $this->info('Building frontend assets for development! This may take a second.');
             try {
@@ -173,7 +191,7 @@ class BuildStaticSiteCommand extends Command
                 $this->warn('Could not run script! Is NPM installed?');
             }
         }
-        
+
         if ($this->option('run-prod')) {
             $this->info('Building frontend assets for production! This may take a second.');
             try {
@@ -182,24 +200,37 @@ class BuildStaticSiteCommand extends Command
                 $this->warn('Could not run script! Is NPM installed?');
             }
         }
-        
+
         $time_end = microtime(true);
         $execution_time = ($time_end - $time_start);
         $this->info('All done! Finished in ' . number_format(
             $execution_time,
             2
-            ) .' seconds. (' . number_format(($execution_time * 1000), 2) . 'ms)');
-            
-            $this->info('Congratulations! 🎉 Your static site has been built!');
-            echo(
-                "Your new homepage is stored here -> file://" . str_replace(
-                    '\\',
-                    '/',
-                    realpath(Hyde::path('_site/index.html'))
-                    )
-                );
-                
-                return 0;
-            }
-        }
-        
+        ) . ' seconds. (' . number_format(($execution_time * 1000), 2) . 'ms)');
+
+        $this->info('Congratulations! 🎉 Your static site has been built!');
+        echo ("Your new homepage is stored here -> file://" . str_replace(
+                '\\',
+                '/',
+                realpath(Hyde::path('_site/index.html'))
+            )
+        );
+
+        return 0;
+    }
+
+    public function purge()
+    {
+        $this->warn('Removing all files from build directory.');
+
+        File::deleteDirectory(Hyde::path('_site'));
+        mkdir(Hyde::path('_site'));
+
+        $this->line('<fg=gray> > Directory purged');
+
+        $this->line(' > Recreating directories');
+        (new CreatesDefaultDirectories)->__invoke();
+
+        $this->line('</>');
+    }
+}

--- a/src/Commands/BuildStaticSiteCommand.php
+++ b/src/Commands/BuildStaticSiteCommand.php
@@ -23,7 +23,10 @@ class BuildStaticSiteCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'build {--pretty : Should the build files be prettified?}';
+    protected $signature = 'build 
+        {--run-dev : Run the NPM dev script after build}
+        {--run-prod : Run the NPM prod script after build}
+        {--pretty : Should the build files be prettified?}';
 
     /**
      * The description of the command.
@@ -123,6 +126,24 @@ class BuildStaticSiteCommand extends Command
                 $this->line(shell_exec('npx prettier _site/ --write'));
             } catch (Exception) {
                 $this->warn('Could not prettify code! Is NPM installed?');
+            }
+        }
+        
+        if ($this->option('run-dev')) {
+            $this->info('Building frontend assets for development! This may take a second.');
+            try {
+                $this->line(shell_exec('npm run dev'));
+            } catch (Exception) {
+                $this->warn('Could not run script! Is NPM installed?');
+            }
+        }
+
+        if ($this->option('run-prod')) {
+            $this->info('Building frontend assets for production! This may take a second.');
+            try {
+                $this->line(shell_exec('npm run prod'));
+            } catch (Exception) {
+                $this->warn('Could not run script! Is NPM installed?');
             }
         }
 


### PR DESCRIPTION
This PR adds a few new options to the build command:

New options:

- --run-dev       Run the NPM run dev script after build to automatically build frontend assets
- --run-prod     Run the NPM run prod script after build to automatically build frontend assets
- --clean           Empties the output directory before building. Perfect to clean up old files.
- --force           Allows file deletions without prompting user for confirmation

It also has a UX improvement where the progress bar is not shown for empty collections. It also adds a splash of color to the progress bar titles.