### PR TITLE
Add the Hyde::getLatestPosts() shorthand to get the latest posts collection

### DIFF
--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -15,7 +15,7 @@
     </header>
 
     <div class="max-w-3xl mx-auto">
-        @foreach(\Hyde\Framework\Models\MarkdownPost::getCollection() as $post)
+        @foreach(Hyde::getLatestPosts() as $post)
         @include('hyde::components.article-excerpt')
         @endforeach
     </div>

--- a/src/Hyde.php
+++ b/src/Hyde.php
@@ -2,6 +2,8 @@
 
 namespace Hyde\Framework;
 
+use Hyde\Framework\Models\MarkdownPost;
+
 /**
  * General interface for Hyde services
  */
@@ -72,5 +74,18 @@ class Hyde
         }
         $route .= $destination ;
         return $route;
+    }
+
+    /**
+     * Get a Laravel Collection of all Posts as MarkdownPost objects.
+     * 
+     * Serves as a static shorthand for \Hyde\Framework\Models\MarkdownPost::getCollection()
+     * @see MarkdownPost::getCollection
+     * 
+     * @return \Illuminate\Support\Collection
+     */
+    public static function getLatestPosts(): \Illuminate\Support\Collection
+    {
+        return \Hyde\Framework\Models\MarkdownPost::getCollection();
     }
 }

--- a/src/Hyde.php
+++ b/src/Hyde.php
@@ -23,6 +23,9 @@ class Hyde
 
     /**
      * Return the path where the Blade views are located
+     * 
+     * @deprecated v0.4.1 as it is not needed
+     * 
      * @return string
      */
     public static function viewPath()


### PR DESCRIPTION
New facade method:
Hyde::getLatestPosts() which serves as a static shorthand for \Hyde\Framework\Models\MarkdownPost::getCollection()
