### PR TITLE
Load commands in service provider instead of config/commands.php

### DIFF
--- a/config/commands.php
+++ b/config/commands.php
@@ -40,15 +40,7 @@ return [
     */
 
     'add' => [
-        Hyde\Framework\Commands\BuildStaticSiteCommand::class,
-        Hyde\Framework\Commands\Debug::class,
-        Hyde\Framework\Commands\MakePostCommand::class,
-        Hyde\Framework\Commands\MakeValidatorCommand::class,
-        Hyde\Framework\Commands\HydePublishViewsCommand::class,
-        Hyde\Framework\Commands\HydePublishConfigsCommand::class,
-        Hyde\Framework\Commands\HydePublishHomepageCommand::class,
-        Hyde\Framework\Commands\HydeInstallerCommand::class,
-        Hyde\Framework\Commands\Validate::class,
+        //
     ],
 
     /*

--- a/src/HydeServiceProvider.php
+++ b/src/HydeServiceProvider.php
@@ -28,6 +28,19 @@ class HydeServiceProvider extends ServiceProvider
                 return InstalledVersions::getVersion('hyde/framework') ?: 'unreleased';
             }
         );
+
+        $this->commands([
+            Commands\HydePublishHomepageCommand::class,
+            Commands\HydePublishConfigsCommand::class,
+            Commands\HydePublishViewsCommand::class,
+            Commands\BuildStaticSiteCommand::class,
+            Commands\HydeInstallerCommand::class,
+            Commands\MakeValidatorCommand::class,
+            Commands\PublishStubsCommand::class,
+            Commands\MakePostCommand::class,
+            Commands\Validate::class,
+            Commands\Debug::class,
+        ]);
     }
 
     /**


### PR DESCRIPTION
Previously, the Hyde commands were loaded in the config which requires the config to be republished whenever new commands are added to keep them in sync.

This PR moves the commands into the Hyde Service Provider instead.