### PR TITLE
Improve Docgen Feature by allowing the output directory to be dynamically changed

### DIFF
--- a/config/hyde.php
+++ b/config/hyde.php
@@ -175,6 +175,24 @@ return [
         'readme',
         'installation',
         'getting-started',
-    ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Documentation Site Output Directory
+    |--------------------------------------------------------------------------
+    |
+    | If you want to store the compiled documentation pages in a different
+    | directory than the default 'docs' directory, for example to set the
+    | specified version, you can specify the directory here.
+    | 
+    | Note that you need to take care as to not set it to something that 
+    | may conflict with other parts, such as media or posts directories.
+    |
+    | The default value is 'docs'.
+    |
+    */
+
+    'docsDirectory' => 'docs',
 
 ];

--- a/resources/views/components/docs/sidebar-header.blade.php
+++ b/resources/views/components/docs/sidebar-header.blade.php
@@ -1,6 +1,6 @@
 <header class="h-16 p-4 border-b flex items-center">
     <h2 class="font-bold opacity-75 hover:opacity-100 w-fit">
-        <a href="../docs/index.html">
+        <a href="../{{ Hyde::docsDirectory() }}/index.html">
             {{ config('hyde.name') }} Docs
         </a>
     </h2>

--- a/src/Actions/GeneratesNavigationMenu.php
+++ b/src/Actions/GeneratesNavigationMenu.php
@@ -82,7 +82,9 @@ class GeneratesNavigationMenu
                     $links[] = [
                         'title' => 'Docs',
                         'route' => $this->getRelativeRoutePathForSlug(
-                            file_exists('_docs/index.md') ? 'docs/index' : 'docs/readme'
+                            file_exists('_docs/index.md')
+                                ? Hyde::docsDirectory() . '/index'
+                                : Hyde::docsDirectory() . '/readme'
                         ),
                         'current' => false,
                         'priority' => 500,

--- a/src/Hyde.php
+++ b/src/Hyde.php
@@ -48,6 +48,15 @@ class Hyde
     }
 
     /**
+     * Get the subdirectory documentation files are stored in
+     * @return string
+     */
+    public static function docsDirectory(): string
+    {
+        return trim(config('hyde.docsDirectory', 'docs'), '/\\');
+    }
+
+    /**
      * Get an absolute path from a supplied relative path.
      *
      * The function returns the fully qualified path to your site's root directory.

--- a/src/StaticPageBuilder.php
+++ b/src/StaticPageBuilder.php
@@ -58,7 +58,10 @@ class StaticPageBuilder
         }
 
         if ($this->page instanceof DocumentationPage) {
-            return $this->save('docs/' . $this->page->slug, $this->compileDocs());
+            if (!file_exists(Hyde::path('_site/' . Hyde::docsDirectory()))) {
+                mkdir(Hyde::path('_site/' . Hyde::docsDirectory()));
+            }
+            return $this->save(Hyde::docsDirectory() . '/' . $this->page->slug, $this->compileDocs());
         }
     }
 


### PR DESCRIPTION
The output directory for the documentation pages can now be changed. The compiled links will automatically be updated too.

For example, this can be used to specify the version being generated. I plan on using this for the https://github.com/hydephp/docs repo.