### PR TITLE
Fix #21 by dynamically routing to the docs index

### DIFF
--- a/resources/views/components/docs/sidebar-header.blade.php
+++ b/resources/views/components/docs/sidebar-header.blade.php
@@ -1,7 +1,11 @@
 <header class="h-16 p-4 border-b flex items-center">
     <h2 class="font-bold opacity-75 hover:opacity-100 w-fit">
-        <a href="../{{ Hyde::docsDirectory() }}/index.html">
+        @if(Hyde::docsIndexPath() !== false)
+        <a href="../{{ Hyde::docsIndexPath() }}">
             {{ config('hyde.name') }} Docs
         </a>
+        @else
+            {{ config('hyde.name') }} Docs
+        @endif
     </h2>
 </header>

--- a/src/Hyde.php
+++ b/src/Hyde.php
@@ -31,6 +31,23 @@ class Hyde
     }
 
     /**
+     * Get the path to the frontpage for the documentation
+     * @return string|false returns false if no frontpage is found
+     */
+    public static function docsIndexPath(): string|false
+    {
+        if (file_exists(Hyde::path('_docs/index.md'))) {
+            return Hyde::docsDirectory() . '/index.html';
+        }
+
+        if (file_exists(Hyde::path('_docs/readme.md'))) {
+            return Hyde::docsDirectory() . '/readme.html';
+        }
+
+        return false;
+    }
+
+    /**
      * Get an absolute path from a supplied relative path.
      *
      * The function returns the fully qualified path to your site's root directory.


### PR DESCRIPTION
Original bug: #21 Documentation sidebar header should link to readme if that exists but an index does not