### PR TITLE
#38 Add a rebuild command to the Hyde CLI to rebuild a specific file

### DIFF
--- a/src/Commands/HydeRebuildStaticSiteCommand.php
+++ b/src/Commands/HydeRebuildStaticSiteCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Hyde\Framework\Commands;
+
+use Exception;
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Services\BuildService;
+use LaravelZero\Framework\Commands\Command;
+
+/**
+ * Hyde Command to build a single static site file.
+ */
+class HydeRebuildStaticSiteCommand extends Command
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'rebuild
+        {path : The relative file path (example: _posts/hello-world.md)}';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Run the static site builder for a single file';
+
+
+    /**
+     * The Service Class.
+     * @var BuildService
+     */
+    protected BuildService $service;
+
+    /**
+     * The source path.
+     * @var string
+     */
+    public string $path;
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $time_start = microtime(true);
+
+        $this->path = $this->sanitizePathString($this->argument('path'));
+
+        try {
+            $this->validate();
+        } catch (Exception $exception) {
+            return $this->handleException($exception);
+        }
+
+
+        $this->service = new BuildService($this->path);
+
+        try {
+            $this->service->execute();
+        } catch (Exception $exception) {
+            return $this->handleException($exception);
+        }
+
+        $time_end = microtime(true);
+        $execution_time = ($time_end - $time_start);
+
+        $this->info('Created ' . $this->createClickableFilepath($this->service->builder->createdFilePath) . ' in ' .number_format(
+            $execution_time,
+            2
+        ).' seconds. ('.number_format(($execution_time * 1000), 2).'ms)');
+
+        return 0;
+    }
+
+    /**
+     * Perform a basic sanitation to strip trailing characters.
+     * @param string $path
+     * @return string
+     */
+    public function sanitizePathString(string $path): string
+    {
+        return ltrim($path, '.\\/');
+    }
+
+    /**
+     * Validate the path to catch common errors.
+     * @throws Exception
+     */
+    public function validate(): void
+    {
+        if (!(
+            str_starts_with($this->path, '_docs') ||
+            str_starts_with($this->path, '_posts') ||
+            str_starts_with($this->path, '_pages') ||
+            str_starts_with($this->path, 'resources/views/pages')
+        )) {
+            throw new Exception("Path [$this->path] is not in a valid source directory.", 400);
+        }
+
+        if (!file_exists(Hyde::path($this->path))) {
+            throw new Exception("File [$this->path] not found.", 404);
+        }
+    }
+
+    public function handleException(Exception $exception)
+    {
+        $this->error('Something went wrong!');
+        $this->warn($exception->getMessage());
+
+        return $exception->getCode();
+    }
+
+    public function createClickableFilepath(string $filepath)
+    {
+        return 'file://'.str_replace(
+            '\\',
+            '/',
+            realpath($filepath)
+        );
+    }
+}

--- a/src/Commands/HydeRebuildStaticSiteCommand.php
+++ b/src/Commands/HydeRebuildStaticSiteCommand.php
@@ -27,7 +27,6 @@ class HydeRebuildStaticSiteCommand extends Command
      */
     protected $description = 'Run the static site builder for a single file';
 
-
     /**
      * The Service Class.
      * @var BuildService
@@ -69,10 +68,15 @@ class HydeRebuildStaticSiteCommand extends Command
         $time_end = microtime(true);
         $execution_time = ($time_end - $time_start);
 
-        $this->info('Created ' . $this->createClickableFilepath($this->service->builder->createdFilePath) . ' in ' .number_format(
-            $execution_time,
-            2
-        ).' seconds. ('.number_format(($execution_time * 1000), 2).'ms)');
+        $this->info(sprintf(
+            "Created %s in %s seconds. (%sms)",
+            $this->createClickableFilepath($this->service->builder->createdFilePath),
+            number_format(
+                $execution_time,
+                2
+            ),
+            number_format(($execution_time * 1000), 2)
+        ));
 
         return 0;
     }
@@ -107,7 +111,12 @@ class HydeRebuildStaticSiteCommand extends Command
         }
     }
 
-    public function handleException(Exception $exception)
+    /**
+     * Output the contents of an exception.
+     * @param Exception $exception
+     * @return int Error code
+     */
+    public function handleException(Exception $exception): int
     {
         $this->error('Something went wrong!');
         $this->warn($exception->getMessage());
@@ -115,6 +124,11 @@ class HydeRebuildStaticSiteCommand extends Command
         return $exception->getCode();
     }
 
+    /**
+     * Create a filepath that can be opened in the browser from a terminal.
+     * @param string $filepath
+     * @return string
+     */
     public function createClickableFilepath(string $filepath)
     {
         return 'file://'.str_replace(

--- a/src/Commands/HydeRebuildStaticSiteCommand.php
+++ b/src/Commands/HydeRebuildStaticSiteCommand.php
@@ -129,7 +129,7 @@ class HydeRebuildStaticSiteCommand extends Command
      * @param string $filepath
      * @return string
      */
-    public function createClickableFilepath(string $filepath)
+    public function createClickableFilepath(string $filepath): string
     {
         return 'file://'.str_replace(
             '\\',

--- a/src/Commands/HydeRebuildStaticSiteCommand.php
+++ b/src/Commands/HydeRebuildStaticSiteCommand.php
@@ -88,7 +88,7 @@ class HydeRebuildStaticSiteCommand extends Command
      */
     public function sanitizePathString(string $path): string
     {
-        return ltrim($path, '.\\/');
+        return str_replace('\\', '/', trim($path, '.\\/'));
     }
 
     /**

--- a/src/HydeServiceProvider.php
+++ b/src/HydeServiceProvider.php
@@ -33,6 +33,7 @@ class HydeServiceProvider extends ServiceProvider
             Commands\HydePublishHomepageCommand::class,
             Commands\HydePublishConfigsCommand::class,
             Commands\HydePublishViewsCommand::class,
+            Commands\HydeRebuildStaticSiteCommand::class,
             Commands\HydeBuildStaticSiteCommand::class,
             Commands\HydeMakeValidatorCommand::class,
             Commands\HydePublishStubsCommand::class,

--- a/src/Services/BuildService.php
+++ b/src/Services/BuildService.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Hyde\Framework\Services;
+
+use Exception;
+use Hyde\Framework\Models\BladePage;
+use Hyde\Framework\Models\MarkdownPage;
+use Hyde\Framework\Models\MarkdownPost;
+use Hyde\Framework\Models\DocumentationPage;
+use Hyde\Framework\DocumentationPageParser;
+use Hyde\Framework\MarkdownPageParser;
+use Hyde\Framework\MarkdownPostParser;
+use Hyde\Framework\StaticPageBuilder;
+
+/**
+ * Build static pages, but intelligently.
+ *
+ * Runs the static page builder for a given path.
+ */
+class BuildService
+{
+    /**
+     * The source file to build.
+     * Should be relative to the Hyde::path() helper.
+     * @var string
+     */
+    public string $filepath;
+
+    /**
+     * The model of the source file.
+     * @var string
+     * @internal
+     */
+    public string $model;
+
+    /**
+     * @param string $filepath
+     */
+    public function __construct(string $filepath)
+    {
+        $this->filepath = $filepath;
+    }
+
+    /**
+     * Execute the service action.
+     * @throws Exception
+     */
+    public function execute()
+    {
+        $this->model = $this->determineModel();
+
+        $this->handle();
+    }
+
+    /**
+     * Handle the service action.
+     * @throws Exception
+     */
+    public function handle(): StaticPageBuilder
+    {
+        if ($this->model === MarkdownPost::class) {
+            $slug = basename(str_replace('_posts/', '', $this->filepath), '.md');
+            return (new StaticPageBuilder((new MarkdownPostParser($slug))->get(), true));
+        }
+
+        if ($this->model === MarkdownPage::class) {
+            $slug = basename(str_replace('_pages/', '', $this->filepath), '.md');
+            return (new StaticPageBuilder((new MarkdownPageParser($slug))->get(), true));
+        }
+
+        if ($this->model === DocumentationPage::class) {
+            $slug = basename(str_replace('_docs/', '', $this->filepath), '.md');
+            return (new StaticPageBuilder((new DocumentationPageParser($slug))->get(), true));
+        }
+
+        if ($this->model === BladePage::class) {
+            $slug = basename(str_replace('resources/views/pages/', '', $this->filepath), '.blade.php');
+            return (new StaticPageBuilder((new BladePage($slug)), true));
+        }
+
+        throw new Exception('Could not run the builder.', 400);
+    }
+
+    /**
+     * Determine the proper model of the source file.
+     * @throws Exception
+     */
+    public function determineModel(): string
+    {
+        if (str_starts_with($this->filepath, '_posts')) {
+            return $this->model = MarkdownPost::class;
+        } elseif (str_starts_with($this->filepath, '_pages')) {
+            return $this->model = MarkdownPage::class;
+        } elseif (str_starts_with($this->filepath, '_docs')) {
+            return $this->model = DocumentationPage::class;
+        } elseif (str_starts_with($this->filepath, 'resources/views/pages')) {
+            return $this->model = BladePage::class;
+        } else {
+            throw new Exception('Invalid source path.', 400);
+        }
+    }
+}

--- a/src/Services/BuildService.php
+++ b/src/Services/BuildService.php
@@ -34,6 +34,13 @@ class BuildService
     public string $model;
 
     /**
+     * The page builder instance.
+     * Used to get debug output from the builder.
+     * @var StaticPageBuilder
+     */
+    public StaticPageBuilder $builder;
+
+    /**
      * @param string $filepath
      */
     public function __construct(string $filepath)
@@ -60,22 +67,22 @@ class BuildService
     {
         if ($this->model === MarkdownPost::class) {
             $slug = basename(str_replace('_posts/', '', $this->filepath), '.md');
-            return (new StaticPageBuilder((new MarkdownPostParser($slug))->get(), true));
+            return $this->builder = (new StaticPageBuilder((new MarkdownPostParser($slug))->get(), true));
         }
 
         if ($this->model === MarkdownPage::class) {
             $slug = basename(str_replace('_pages/', '', $this->filepath), '.md');
-            return (new StaticPageBuilder((new MarkdownPageParser($slug))->get(), true));
+            return $this->builder = (new StaticPageBuilder((new MarkdownPageParser($slug))->get(), true));
         }
 
         if ($this->model === DocumentationPage::class) {
             $slug = basename(str_replace('_docs/', '', $this->filepath), '.md');
-            return (new StaticPageBuilder((new DocumentationPageParser($slug))->get(), true));
+            return $this->builder = (new StaticPageBuilder((new DocumentationPageParser($slug))->get(), true));
         }
 
         if ($this->model === BladePage::class) {
             $slug = basename(str_replace('resources/views/pages/', '', $this->filepath), '.blade.php');
-            return (new StaticPageBuilder((new BladePage($slug)), true));
+            return $this->builder = (new StaticPageBuilder((new BladePage($slug)), true));
         }
 
         throw new Exception('Could not run the builder.', 400);

--- a/src/StaticPageBuilder.php
+++ b/src/StaticPageBuilder.php
@@ -10,7 +10,7 @@ use Hyde\Framework\Models\MarkdownPost;
 use JetBrains\PhpStorm\ArrayShape;
 
 /**
- * Generates a static HTML page and saves it.
+ * Converts a Page Model into a static HTML page.
  */
 class StaticPageBuilder
 {


### PR DESCRIPTION
# The rebuild command

Using the `php hyde build` command is great and all that, but when you just need to update that one file it gets a little... overkill.

Let's solve that! Use the `php hyde rebuild <file>` command!

In the future it will support an array of files, but for now, the rebuild command will recompile just that file.

## Behind the scenes

The command acts like an alias to a new service class, the Build Service, which accepts a single source path.

We can in the future make a wrapper for the service that allows for an array input which then starts a build loop of build service classes.

Once the service class is instantiated we call the execute action method to start the build loop. If here the service determines which model to render based on the file path prefix. If a file is not found or a model does not exist an error will be thrown.

The service flow goes like this:
Command is run > a service class is instantiated, the command arguments are passed to the constructor > execute the action.
This flow allows for plenty of opportunities to add validation and confirmation.