### PR TITLE
Fix the 404 route bug

### DIFF
--- a/resources/views/pages/404.blade.php
+++ b/resources/views/pages/404.blade.php
@@ -478,7 +478,7 @@
                     Sorry, the page you are looking for could not be found.
                 </p>
 
-                <a href="index.html">
+                <a href="{{ config('hyde.site_url') ?? '/' }}">
                     <button
                         class="bg-transparent text-grey-darkest font-bold uppercase tracking-wide py-3 px-6 border-2 border-grey-light hover:border-grey rounded-lg">
                         Go Home


### PR DESCRIPTION
Fix the bug where the 404 page "go home" button did not work on nested pages by first attempting to link to the app url if it is set, otherwise directly to the root path (href="/").