### PR TITLE
Add support for nesting the documentation pages

### DIFF
--- a/src/StaticPageBuilder.php
+++ b/src/StaticPageBuilder.php
@@ -127,7 +127,7 @@ class StaticPageBuilder
             'docs' => $this->page,
             'title' => $this->page->title,
             'markdown' => MarkdownConverter::parse($this->page->content),
-            'currentPage' => 'docs/'.$this->page->slug,
+            'currentPage' => trim(config('hyde.docsDirectory', 'docs'), '\\/') . '/' . $this->page->slug
         ])->render();
     }
 


### PR DESCRIPTION
The currentPage value which was hardcoded with the path prefix `docs` which is a bug since it can be overridden in the config. This PR fixes that, and also allows nested documentation output directories to access the site styles, thus providing full support for nested documentation pages.

In other words, this config setting now works:
```php
'docsDirectory' => 'docs/master',
```