### PR TITLE
Fix the documentation page header link

### DIFF
--- a/resources/views/components/docs/sidebar-header.blade.php
+++ b/resources/views/components/docs/sidebar-header.blade.php
@@ -1,7 +1,7 @@
 <header class="h-16 p-4 border-b flex items-center">
     <h2 class="font-bold opacity-75 hover:opacity-100 w-fit">
         @if(Hyde::docsIndexPath() !== false)
-        <a href="{{ Hyde::relativePath(Hyde::docsIndexPath(), $currentPage) }}">
+        <a href="{{ basename(Hyde::docsIndexPath()) }}">
             {{ config('hyde.name') }} Docs
         </a>
         @else


### PR DESCRIPTION
The documentation heading link in the last patch did not work as expected, this PR should fix that.