### PR TITLE
Fix bug #47 StaticPageBuilder not able to create nested documentation directories

### DIFF
--- a/src/StaticPageBuilder.php
+++ b/src/StaticPageBuilder.php
@@ -63,7 +63,7 @@ class StaticPageBuilder
 
         if ($this->page instanceof DocumentationPage) {
             if (! file_exists(Hyde::path('_site/'.Hyde::docsDirectory()))) {
-                mkdir(Hyde::path('_site/'.Hyde::docsDirectory()));
+                mkdir(Hyde::path('_site/'.Hyde::docsDirectory()), recursive: true);
             }
 
             return $this->save(Hyde::docsDirectory().'/'.$this->page->slug, $this->compileDocs());


### PR DESCRIPTION
Fixed by allowing recursion in the `mkdir` function call. The commit is backwards compatible.