### PR TITLE
Add a favicon link automatically if the file exists

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:site_name" content="{{ config('hyde.name', 'HydePHP') }}">
 
+    @if (file_exists(Hyde::path('_media/favicon.ico')))
+        <link rel="shortcut icon" href="{{ Hyde::relativePath('media/favicon.ico', $currentPage) }}" type="image/x-icon">
+    @endif
+
     @stack('meta')
     
     @include('hyde::layouts.meta') 


### PR DESCRIPTION
Checks if a `favicon.ico` file exists in the `_media` directory, and if so, injects a link with using the Hyde relative path helper.