### PR TITLE
Create new command to scaffold pages

### DIFF
--- a/src/Actions/CreatesNewPageSourceFile.php
+++ b/src/Actions/CreatesNewPageSourceFile.php
@@ -25,6 +25,11 @@ class CreatesNewPageSourceFile
 	 */
 	public string $slug;
 
+	/**
+	 * The file path.
+	 */
+	public string $path;
+
     /**
      * Construct the class.
      *
@@ -67,8 +72,9 @@ class CreatesNewPageSourceFile
 	 */
 	public function createMarkdownFile(): int|false
     {
+		$this->path = Hyde::path("_pages/$this->slug.md");
 		return file_put_contents(
-			Hyde::path("_pages/$this->slug.md"),
+			$this->path,
 			"---\ntitle: $this->title\n---\n\n# $this->title\n"
 		);
 	}
@@ -80,8 +86,10 @@ class CreatesNewPageSourceFile
 	 */
 	public function createBladeFile(): int|false
     {
+		$this->path = Hyde::path("resources/views/pages/$this->slug.blade.php");
+
 		return file_put_contents(
-			Hyde::path("resources/views/pages/$this->slug.blade.php"),
+			$this->path,
 			<<<EOF
 @extends('hyde::layouts.app')
 @section('content')

--- a/src/Actions/CreatesNewPageSourceFile.php
+++ b/src/Actions/CreatesNewPageSourceFile.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Str;
 /**
  * Scaffold a new Markdown or Blade page
  */
-class CreatesNewStaticPageSourceFile
+class CreatesNewPageSourceFile
 {
 	/**
 	 * The Page title.

--- a/src/Actions/CreatesNewStaticPageSourceFile.php
+++ b/src/Actions/CreatesNewStaticPageSourceFile.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Actions;
 
+use Exception;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\MarkdownPage;
@@ -25,10 +26,11 @@ class CreatesNewStaticPageSourceFile
 	public string $slug;
 
     /**
-	 * Construct the class.
-	 *
-	 * @param string $title - The page title, will be used to generate the slug
-	 * @param string $type - The page type, either 'markdown' or 'blade'
+     * Construct the class.
+     *
+     * @param string $title - The page title, will be used to generate the slug
+     * @param string $type - The page type, either 'markdown' or 'blade'
+     * @throws Exception if the page type is not 'markdown' or 'blade'
 	 */
 	public function __construct(string $title, string $type = MarkdownPage::class)
 	{
@@ -42,10 +44,11 @@ class CreatesNewStaticPageSourceFile
      * Create the page.
      *
      * @param string $type - The page type, either 'markdown' or 'blade'
-     * @throws \Exception if the page type is not 'markdown' or 'blade'
+     * @throws Exception if the page type is not 'markdown' or 'blade'
+	 * @return int|false the size of the file created, or false on failure.
 	 */
-	public function createPage(string $type)
-	{
+	public function createPage(string $type): int|false
+    {
 		// Check that the page type is either 'markdown' or 'blade'
 		if ($type === MarkdownPage::class) {
 			return $this->createMarkdownFile();
@@ -54,36 +57,43 @@ class CreatesNewStaticPageSourceFile
 			return $this->createBladeFile();
 		} 
 
-		throw new \Exception('The page type must be either "markdown" or "blade"');
+		throw new Exception('The page type must be either "markdown" or "blade"');
 	}
 
 	/**
 	 * Create the Markdown file.
+	 * 
+	 * @return int|false the size of the file created, or false on failure.
 	 */
-	public function createMarkdownFile()
-	{
+	public function createMarkdownFile(): int|false
+    {
 		return file_put_contents(
-			Hyde::path("_pages/{$this->slug}.md"),
-			"---\ntitle: {$this->title}\n---\n\n# {$this->title}\n"
+			Hyde::path("_pages/$this->slug.md"),
+			"---\ntitle: $this->title\n---\n\n# $this->title\n"
 		);
 	}
 
 	/**
 	 * Create the Blade file.
+	 * 
+	 * @return int|false the size of the file created, or false on failure.
 	 */
-	public function createBladeFile()
-	{
+	public function createBladeFile(): int|false
+    {
 		return file_put_contents(
-			Hyde::path("resources/views/pages/{$this->slug}.blade.php"),
-			"@extends('hyde::layouts.app')
+			Hyde::path("resources/views/pages/$this->slug.blade.php"),
+			<<<EOF
+@extends('hyde::layouts.app')
 @section('content')
-@php(\$title = \"{$this->title}\")
+@php(\$title = "$this->title")
 
-<main class=\"mx-auto max-w-7xl py-16 px-8\">
-	<h1 class=\"text-center text-3xl font-bold\">{$this->title}</h1>
+<main class="mx-auto max-w-7xl py-16 px-8">
+	<h1 class="text-center text-3xl font-bold">$this->title</h1>
 </main>
 
 @endsection
-");
+
+EOF
+);
 	}
 }

--- a/src/Actions/CreatesNewStaticPageSourceFile.php
+++ b/src/Actions/CreatesNewStaticPageSourceFile.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Hyde\Framework\Actions;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\BladePage;
+use Hyde\Framework\Models\MarkdownPage;
+use Illuminate\Support\Str;
+
+/**
+ * Scaffold a new Markdown or Blade page
+ */
+class CreatesNewStaticPageSourceFile
+{
+	/**
+	 * The Page title.
+	 *
+	 * @var string
+	 */
+	public string $title;
+
+	/**
+	 * The Page slug.
+	 */
+	public string $slug;
+
+    /**
+	 * Construct the class.
+	 *
+	 * @param string $title - The page title, will be used to generate the slug
+	 * @param string $type - The page type, either 'markdown' or 'blade'
+	 */
+	public function __construct(string $title, string $type = MarkdownPage::class)
+	{
+		$this->title = $title;
+		$this->slug = Str::slug($title);
+
+		$this->createPage($type);
+	}
+
+    /**
+     * Create the page.
+     *
+     * @param string $type - The page type, either 'markdown' or 'blade'
+     * @throws \Exception if the page type is not 'markdown' or 'blade'
+	 */
+	public function createPage(string $type)
+	{
+		// Check that the page type is either 'markdown' or 'blade'
+		if ($type === MarkdownPage::class) {
+			return $this->createMarkdownFile();
+		} 
+		if ($type === BladePage::class) {
+			return $this->createBladeFile();
+		} 
+
+		throw new \Exception('The page type must be either "markdown" or "blade"');
+	}
+
+	/**
+	 * Create the Markdown file.
+	 */
+	public function createMarkdownFile()
+	{
+		return file_put_contents(
+			Hyde::path("_pages/{$this->slug}.md"),
+			"---\ntitle: {$this->title}\n---\n\n# {$this->title}\n"
+		);
+	}
+
+	/**
+	 * Create the Blade file.
+	 */
+	public function createBladeFile()
+	{
+		return file_put_contents(
+			Hyde::path("resources/views/pages/{$this->slug}.blade.php"),
+			"@extends('hyde::layouts.app')
+@section('content')
+@php(\$title = \"{$this->title}\")
+
+<main class=\"mx-auto max-w-7xl py-16 px-8\">
+	<h1 class=\"text-center text-3xl font-bold\">{$this->title}</h1>
+</main>
+
+@endsection
+");
+	}
+}

--- a/src/Commands/HydeMakePageCommand.php
+++ b/src/Commands/HydeMakePageCommand.php
@@ -3,6 +3,9 @@
 namespace Hyde\Framework\Commands;
 
 use Exception;
+use Hyde\Framework\Actions\CreatesNewPageSourceFile;
+use Hyde\Framework\Models\BladePage;
+use Hyde\Framework\Models\MarkdownPage;
 use LaravelZero\Framework\Commands\Command;
 
 /**
@@ -37,29 +40,31 @@ class HydeMakePageCommand extends Command
 	 */
 	public string $type;
 
-	/**
-	 * Execute the console command.
-	 * 
-	 * @return int
-	 */
+    /**
+     * Execute the console command.
+     *
+     * @return int the exit code of the command.
+     * @throws Exception if the page type is invalid.
+     */
 	public function handle(): int
 	{
 		$this->title('Creating a new page!');
 
 		$this->validateOptions();
 
-		$creator = new \Hyde\Framework\Actions\CreatesNewPageSourceFile($this->title, $this->type);
+		$creator = new CreatesNewPageSourceFile($this->title, $this->type);
 
 		$this->line("Created file $creator->path");
 
 		return 0;
 	}
 
-	/**
-	 * Validate the options passed to the command.
-	 * 
-	 * @return void
-	 */
+    /**
+     * Validate the options passed to the command.
+     *
+     * @return void
+     * @throws Exception if the page type is invalid.
+     */
 	protected function validateOptions(): void
 	{
 		$this->title = $this->argument('title');
@@ -72,9 +77,9 @@ class HydeMakePageCommand extends Command
 
 		// Set the type to the fully qualified class name
 		if ($type === 'markdown') {
-			$this->type = \Hyde\Framework\Models\MarkdownPage::class;
+			$this->type = MarkdownPage::class;
 		} else {
-			$this->type = \Hyde\Framework\Models\BladePage::class;
+			$this->type = BladePage::class;
 		}
 	}
 }

--- a/src/Commands/HydeMakePageCommand.php
+++ b/src/Commands/HydeMakePageCommand.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Commands;
 
+use Exception;
 use LaravelZero\Framework\Commands\Command;
 
 /**
@@ -61,20 +62,13 @@ class HydeMakePageCommand extends Command
 	 */
 	protected function validateOptions(): void
 	{
-		$title = $this->argument('title');
+		$this->title = $this->argument('title');
+		
 		$type = $this->option('type') ?? 'markdown';
 
 		if (!in_array($type, ['markdown', 'blade'])) {
-			$this->error("Invalid page type: $type");
-			exit(1);
+			throw new Exception("Invalid page type: $type", 400);
 		}
-
-		if (empty($title)) {
-			$this->error('You must specify a title for the page');
-			exit(1);
-		}
-
-		$this->title = $title;
 
 		// Set the type to the fully qualified class name
 		if ($type === 'markdown') {

--- a/src/Commands/HydeMakePageCommand.php
+++ b/src/Commands/HydeMakePageCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Hyde\Framework\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+
+/**
+ * Hyde Command to scaffold a new Markdown or Blade page file.
+ */
+class HydeMakePageCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+    protected $signature = 'make:page 
+		{title : The name of the page file to create. Will be used to generate the slug}
+		{--type=markdown : The type of page to create (markdown or blade)}
+		{--force : Overwrite any existing files}';
+
+	/**
+	 * The console command description.
+	 * 
+	 * @var string
+	 */
+    protected $description = 'Scaffold a new Markdown or Blade page file';
+
+	/**
+	 * The page title.
+	 */
+	public string $title;
+
+	/**
+	 * The page type.
+	 */
+	public string $type;
+
+	/**
+	 * Execute the console command.
+	 * 
+	 * @return int
+	 */
+	public function handle(): int
+	{
+		$this->title('Creating a new page!');
+
+		$this->validateOptions();
+
+		$creator = new \Hyde\Framework\Actions\CreatesNewPageSourceFile($this->title, $this->type);
+
+		$this->line("Created file $creator->path");
+
+		return 0;
+	}
+
+	/**
+	 * Validate the options passed to the command.
+	 * 
+	 * @return void
+	 */
+	protected function validateOptions(): void
+	{
+		$title = $this->argument('title');
+		$type = $this->option('type') ?? 'markdown';
+
+		if (!in_array($type, ['markdown', 'blade'])) {
+			$this->error("Invalid page type: $type");
+			exit(1);
+		}
+
+		if (empty($title)) {
+			$this->error('You must specify a title for the page');
+			exit(1);
+		}
+
+		$this->title = $title;
+
+		// Set the type to the fully qualified class name
+		if ($type === 'markdown') {
+			$this->type = \Hyde\Framework\Models\MarkdownPage::class;
+		} else {
+			$this->type = \Hyde\Framework\Models\BladePage::class;
+		}
+	}
+}

--- a/src/Commands/HydeMakePageCommand.php
+++ b/src/Commands/HydeMakePageCommand.php
@@ -64,7 +64,7 @@ class HydeMakePageCommand extends Command
 	{
 		$this->title = $this->argument('title');
 		
-		$type = $this->option('type') ?? 'markdown';
+		$type = strtolower($this->option('type') ?? 'markdown');
 
 		if (!in_array($type, ['markdown', 'blade'])) {
 			throw new Exception("Invalid page type: $type", 400);

--- a/src/Commands/HydeMakePageCommand.php
+++ b/src/Commands/HydeMakePageCommand.php
@@ -40,6 +40,11 @@ class HydeMakePageCommand extends Command
 	 */
 	public string $type;
 
+	/**
+	 * Can the file be overwritten?
+	 */
+	public bool $force;
+
     /**
      * Execute the console command.
      *
@@ -50,11 +55,15 @@ class HydeMakePageCommand extends Command
 	{
 		$this->title('Creating a new page!');
 
+		$this->title = $this->argument('title');
+
 		$this->validateOptions();
 
-		$creator = new CreatesNewPageSourceFile($this->title, $this->type);
+		$this->force = $this->option('force') ?? false;
 
-		$this->line("Created file $creator->path");
+		$creator = new CreatesNewPageSourceFile($this->title, $this->type, $this->force);
+
+		$this->info("Created file $creator->path");
 
 		return 0;
 	}
@@ -67,8 +76,6 @@ class HydeMakePageCommand extends Command
      */
 	protected function validateOptions(): void
 	{
-		$this->title = $this->argument('title');
-		
 		$type = strtolower($this->option('type') ?? 'markdown');
 
 		if (!in_array($type, ['markdown', 'blade'])) {

--- a/src/HydeServiceProvider.php
+++ b/src/HydeServiceProvider.php
@@ -38,6 +38,7 @@ class HydeServiceProvider extends ServiceProvider
             Commands\HydeMakeValidatorCommand::class,
             Commands\HydePublishStubsCommand::class,
             Commands\HydeMakePostCommand::class,
+            Commands\HydeMakePageCommand::class,
             Commands\HydeValidateCommand::class,
             Commands\HydeDebugCommand::class,
         ]);


### PR DESCRIPTION
We have a neat command to create blog posts. We should have one for pages as well. We can use a flag option to select if it should be a Markdown or a Blade pages.

With Markdown the selected title will be added as a front matter, with Blade the default layout will be used as a stub, and the PHP title injected.