### PR TITLE
Rewrite main navigation menu

### DIFF
--- a/resources/views/components/navigation/navigation-link.blade.php
+++ b/resources/views/components/navigation/navigation-link.blade.php
@@ -1,0 +1,4 @@
+<a href="{{ $item['route'] }}" {{ $item['current'] ? 'aria-current="page"' : '' }} 
+	@class(['block my-2 md:my-0 md:inline-block text-gray-700 hover:text-gray-900 md:mx-2 py-1', 'border-l-4 border-indigo-500 md:border-none font-medium -ml-6 pl-5 md:ml-0 md:pl-0' => $item['current']])>
+	{{ $item['title'] }}
+</a>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,58 +1,26 @@
 @php
-	$links = Hyde\Framework\Actions\GeneratesNavigationMenu::getNavigationLinks($currentPage);
-	$homeRoute = ($links[array_search('Home', array_column($links, 'title'))])['route'] ?? 'index.html';
+$links = Hyde\Framework\Actions\GeneratesNavigationMenu::getNavigationLinks($currentPage);
+$homeRoute = ($links[array_search('Home', array_column($links, 'title'))])['route'] ?? 'index.html';
 @endphp
 
-<nav id="main-navigation" class="flex flex-row items-center justify-between w-full h-16 p-4 overflow-hidden shadow-lg sm:shadow-xl md:shadow-none z-20" aria-label="Primary Navigation Menu">
-	<header id="navigation-brand">
+<nav class="flex items-center justify-between flex-wrap p-4 shadow-lg sm:shadow-xl md:shadow-none">
+	<div class="flex items-center flex-shrink-0 text-gray-700 mr-6">
 		<a href="{{ $homeRoute }}" class="font-bold px-4">
 			{{ config('hyde.name', 'HydePHP') }}
 		</a>
-	</header>
-
-	<button class="navigation-toggle-button md:hidden px-4" title="Open navigation menu" onClick="showNavigation()">
-		<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
-	</button>
-
-	<ul id="desktop-navigation-links" class="hidden md:flex">
-		@foreach ($links as $item)
-			<li>
-				@if($item['current'])
-					<a href="{{ $item['route'] }}" aria-current="page" class="current">{{ $item['title'] }}</a>
-				@else
-					<a href="{{ $item['route'] }}">{{ $item['title'] }}</a>
-				@endif
-			</li>
-		@endforeach
-	</ul>
-</nav>
-
-<nav id="mobile-navigation" class="hidden flex-col absolute top-0 w-full shadow-lg sm:shadow-xl  bg-white z-30" aria-label="Primary Navigation Menu">
-	<div class="w-full flex flex-row items-center justify-between p-4 h-16 border-b">
-		<header id="navigation-brand">
-			<a href="{{ $homeRoute }}" class="font-bold px-4">
-				{{ config('hyde.name', 'HydePHP') }}
-			</a>
-		</header>
-
-		<button class="navigation-toggle-button px-4" title="Close navigation menu" onClick="hideNavigation()">
-			<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
+	</div>
+	<div class="block md:hidden">
+		<button class="flex items-center px-3 py-1 hover:text-gray-700">
+			<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><title>Menu</title><path d="M0 0h24v24H0z" fill="none"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
 		</button>
 	</div>
-
-	<ul id="mobile-navigation-links" class="block w-full p-4 overflow-y-auto">
-		@foreach ($links as $item)
-			<li @class([
-					'py-2',
-					'list-item',
-					'list-item-active' => $item['current']
-				])>
-				@if($item['current'])
-					<a href="{{ $item['route'] }}" aria-current="page" class="text-indigo-500">{{ $item['title'] }}</a>
-				@else
-					<a href="{{ $item['route'] }}" class="hover:text-indigo-500">{{ $item['title'] }}</a>
-				@endif
+	<div class="w-full block flex-grow md:flex md:items-center md:w-auto px-6 -mx-4 border-t mt-3 pt-3 md:border-none md:mt-0 md:py-0">
+		<ul class="md:flex-grow md:flex justify-end">
+			@foreach ($links as $item)
+			<li>
+				@include('hyde::components.navigation.navigation-link')
 			</li>
-		@endforeach
-	</ul>
+			@endforeach
+		</ul>
+	</div>
 </nav>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -3,18 +3,19 @@ $links = Hyde\Framework\Actions\GeneratesNavigationMenu::getNavigationLinks($cur
 $homeRoute = ($links[array_search('Home', array_column($links, 'title'))])['route'] ?? 'index.html';
 @endphp
 
-<nav class="flex items-center justify-between flex-wrap p-4 shadow-lg sm:shadow-xl md:shadow-none">
+<nav id="main-navigation" class="flex items-center justify-between flex-wrap p-4 shadow-lg sm:shadow-xl md:shadow-none">
 	<div class="flex items-center flex-shrink-0 text-gray-700 mr-6">
 		<a href="{{ $homeRoute }}" class="font-bold px-4">
 			{{ config('hyde.name', 'HydePHP') }}
 		</a>
 	</div>
 	<div class="block md:hidden">
-		<button class="flex items-center px-3 py-1 hover:text-gray-700">
-			<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><title>Menu</title><path d="M0 0h24v24H0z" fill="none"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+		<button class="flex items-center px-3 py-1 hover:text-gray-700" onclick="toggleNavigation()">
+			<svg style="display: block;" id="open-main-navigation-menu-icon" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><title>Open Menu</title><path d="M0 0h24v24H0z" fill="none"/><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
+			<svg style="display: none;" id="close-main-navigation-menu-icon" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><title>Close Menu</title> <path d="M0 0h24v24H0z" fill="none"></path> <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path> </svg>
 		</button>
 	</div>
-	<div class="w-full block flex-grow md:flex md:items-center md:w-auto px-6 -mx-4 border-t mt-3 pt-3 md:border-none md:mt-0 md:py-0">
+	<div id="main-navigation-links" class="w-full md:block flex-grow md:flex md:items-center md:w-auto px-6 -mx-4 border-t mt-3 pt-3 md:border-none md:mt-0 md:py-0 hidden">
 		<ul class="md:flex-grow md:flex justify-end">
 			@foreach ($links as $item)
 			<li>


### PR DESCRIPTION
This PR rewrites the main navigation menu in accordance with #59 to keep a single source of truth for the navigation menu.

Before this PR there were two separate DOM elements for the main navigation menu. This PR merges them into one single HTML element which makes it much easier to maintain as we no longer need to keep the menus synced.

See https://github.com/hydephp/hyde/pull/58 for the necessary frontend styles and script updates.