### PR TITLE
Change blade source directory to _pages

### DIFF
--- a/config/view.php
+++ b/config/view.php
@@ -3,6 +3,7 @@
 return [
     'paths' => [
         resource_path('views'),
+        base_path('_pages')
     ],
 
     'compiled' => env(

--- a/src/Actions/CreatesDefaultDirectories.php
+++ b/src/Actions/CreatesDefaultDirectories.php
@@ -31,7 +31,7 @@ class CreatesDefaultDirectories
         '_site/posts',
         '_site/media',
         '_site/docs',
-        'resources/views/pages',
+        '_pages',
     ];
 
     /**

--- a/src/Actions/CreatesNewPageSourceFile.php
+++ b/src/Actions/CreatesNewPageSourceFile.php
@@ -108,7 +108,7 @@ class CreatesNewPageSourceFile
      */
     public function createBladeFile(): int|false
     {
-        $this->path = Hyde::path("resources/views/pages/$this->slug.blade.php");
+        $this->path = Hyde::path("_pages/$this->slug.blade.php");
 
         $this->canSaveFile($this->path);
 

--- a/src/Actions/GeneratesNavigationMenu.php
+++ b/src/Actions/GeneratesNavigationMenu.php
@@ -162,7 +162,7 @@ class GeneratesNavigationMenu
     {
         $array = [];
 
-        foreach (glob(Hyde::path('resources/views/pages/*.blade.php')) as $path) {
+        foreach (glob(Hyde::path('_pages/*.blade.php')) as $path) {
             $array[] = basename($path, '.blade.php');
         }
 

--- a/src/Actions/PublishesHomepageView.php
+++ b/src/Actions/PublishesHomepageView.php
@@ -41,7 +41,7 @@ class PublishesHomepageView implements ActionContract
 
         return Hyde::copy(
             Hyde::vendorPath(static::$homePages[$this->selected]['path']),
-            Hyde::path('resources/views/pages/index.blade.php'),
+            Hyde::path('_pages/index.blade.php'),
             $this->force
         );
     }

--- a/src/Commands/HydePublishHomepageCommand.php
+++ b/src/Commands/HydePublishHomepageCommand.php
@@ -101,12 +101,12 @@ class HydePublishHomepageCommand extends Command
 
     protected function canExistingIndexFileBeOverwritten(): bool
     {
-        if (! file_exists(Hyde::path('resources/views/pages/index.blade.php')) || $this->option('force')) {
+        if (! file_exists(Hyde::path('_pages/index.blade.php')) || $this->option('force')) {
             return true;
         }
 
         return FileCacheService::checksumMatchesAny(FileCacheService::unixsumFile(
-            Hyde::path('resources/views/pages/index.blade.php')
+            Hyde::path('_pages/index.blade.php')
         )) ?? $this->option('force');
     }
 }

--- a/src/Commands/HydePublishTestFilesCommand.php
+++ b/src/Commands/HydePublishTestFilesCommand.php
@@ -63,7 +63,7 @@ class HydePublishTestFilesCommand extends Command
         );
 
         copy(
-            Hyde::path('vendor/hyde/framework/_pages/404.blade.php'),
+            Hyde::path('vendor/hyde/framework/resources/views/pages/404.blade.php'),
             Hyde::path('_pages/404.blade.php')
         );
 

--- a/src/Commands/HydePublishTestFilesCommand.php
+++ b/src/Commands/HydePublishTestFilesCommand.php
@@ -59,12 +59,12 @@ class HydePublishTestFilesCommand extends Command
         // outside of testing I think it's okay.
         copy(
             Hyde::path('vendor/hyde/framework/resources/views/homepages/post-feed.blade.php'),
-            Hyde::path('resources/views/pages/index.blade.php')
+            Hyde::path('_pages/index.blade.php')
         );
 
         copy(
-            Hyde::path('vendor/hyde/framework/resources/views/pages/404.blade.php'),
-            Hyde::path('resources/views/pages/404.blade.php')
+            Hyde::path('vendor/hyde/framework/_pages/404.blade.php'),
+            Hyde::path('_pages/404.blade.php')
         );
 
         $this->info('Done!');

--- a/src/Commands/HydeRebuildStaticSiteCommand.php
+++ b/src/Commands/HydeRebuildStaticSiteCommand.php
@@ -113,7 +113,7 @@ class HydeRebuildStaticSiteCommand extends Command
         if (! (str_starts_with($this->path, '_docs') ||
             str_starts_with($this->path, '_posts') ||
             str_starts_with($this->path, '_pages') ||
-            str_starts_with($this->path, 'resources/views/pages')
+            str_starts_with($this->path, '_pages')
         )) {
             throw new Exception("Path [$this->path] is not in a valid source directory.", 400);
         }

--- a/src/HydeServiceProvider.php
+++ b/src/HydeServiceProvider.php
@@ -70,7 +70,7 @@ class HydeServiceProvider extends ServiceProvider
         ], 'hyde-components');
 
         $this->publishes([
-            __DIR__.'/../resources/views/pages/404.blade.php' => resource_path('views/pages/404.blade.php'),
+            __DIR__.'/../_pages/404.blade.php' => resource_path('views/pages/404.blade.php'),
         ], 'hyde-page-404');
     }
 }

--- a/src/Models/BladePage.php
+++ b/src/Models/BladePage.php
@@ -26,7 +26,7 @@ class BladePage extends AbstractPage
         $this->view = $view;
     }
 
-    public static string $sourceDirectory = 'resources/views/pages';
+    public static string $sourceDirectory = '_pages';
     public static string $fileExtension = '.blade.php';
     public static string $parserClass = self::class;
 

--- a/src/Services/BuildService.php
+++ b/src/Services/BuildService.php
@@ -67,7 +67,7 @@ class BuildService
             return DocumentationPage::class;
         }
 
-        if (str_starts_with($filepath, 'resources/views/pages')) {
+        if (str_starts_with($filepath, '_pages')) {
             return BladePage::class;
         }
 

--- a/src/Services/BuildService.php
+++ b/src/Services/BuildService.php
@@ -59,15 +59,15 @@ class BuildService
             return MarkdownPost::class;
         }
 
-        if (str_starts_with($filepath, '_pages')) {
-            return MarkdownPage::class;
-        }
-
         if (str_starts_with($filepath, '_docs')) {
             return DocumentationPage::class;
         }
 
-        if (str_starts_with($filepath, '_pages')) {
+        if (str_starts_with($filepath, '_pages') && str_ends_with($filepath, '.md')) {
+            return MarkdownPage::class;
+        }
+        
+        if (str_starts_with($filepath, '_pages') && str_ends_with($filepath, '.blade.php')) {
             return BladePage::class;
         }
 

--- a/src/Services/CollectionService.php
+++ b/src/Services/CollectionService.php
@@ -54,7 +54,7 @@ class CollectionService
     {
         $array = [];
 
-        foreach (glob(Hyde::path('resources/views/pages/*.blade.php')) as $filepath) {
+        foreach (glob(Hyde::path('_pages/*.blade.php')) as $filepath) {
             $array[] = basename($filepath, '.blade.php');
         }
 

--- a/src/StaticPageBuilder.php
+++ b/src/StaticPageBuilder.php
@@ -123,7 +123,7 @@ class StaticPageBuilder
      */
     private function compileView(): string
     {
-        return view('pages/'.$this->page->view, [
+        return view($this->page->view, [
             'currentPage' => $this->page->view,
         ])->render();
     }


### PR DESCRIPTION
Changes: Blade pages are now stored in the `_pages` directory, same as Markdown pages.

The config/view.php is updated to include the new source directory. Run php hyde publish:configs --force to update.

