### PR TITLE
Deprecate internal abstract class HydeBasePublishingCommand

### DIFF
--- a/src/Commands/HydeBasePublishingCommand.php
+++ b/src/Commands/HydeBasePublishingCommand.php
@@ -16,6 +16,7 @@ use League\Flysystem\Visibility;
 /**
  * Base command to publish the Hyde assets.
  *
+ *   @deprecated version 0.10.0, see PublishesDefaultFrontendResourceFiles and HydePublishFrontendResourcesCommand for suggested implementation.
  * @internal
  *
  * Based on Illuminate\Foundation\Console\VendorPublishCommand


### PR DESCRIPTION
Deprecated as it adds unnecessary complexity.

Call usages can be refactored similarly to the method used here, where the command serves as a wrapper for the action.
Hyde\Framework\Actions\PublishesDefaultFrontendResourceFiles 
Hyde\Framework\Commands\HydePublishFrontendResourcesCommand
