### PR TITLE
Strip front matter from documentation pages

### DIFF
--- a/src/DocumentationPageParser.php
+++ b/src/DocumentationPageParser.php
@@ -3,23 +3,30 @@
 namespace Hyde\Framework;
 
 use Hyde\Framework\Models\DocumentationPage;
+use Hyde\Framework\Services\MarkdownFileService;
 
 class DocumentationPageParser extends AbstractPageParser
 {
     protected string $pageModel = DocumentationPage::class;
     protected string $slug;
 
-    public string $body;
     public string $title;
+    public string $body;
 
     public function execute(): void
     {
-        $stream = file_get_contents(Hyde::path("_docs/$this->slug.md"));
+        $document = (new MarkdownFileService(
+            Hyde::path("_docs/$this->slug.md")
+        ))->get();
 
-        $this->title = $this->findTitleTag($stream) ??
-            Hyde::titleFromSlug($this->slug);
+        if (isset($document->matter['title'])) {
+            $this->title = $document->matter['title'];
+        } else {
+            $this->title = $this->findTitleTag($document->body) ??
+                Hyde::titleFromSlug($this->slug);
+        }
 
-        $this->body = $stream;
+        $this->body = $document->body;
     }
 
     /**

--- a/src/MarkdownPageParser.php
+++ b/src/MarkdownPageParser.php
@@ -5,9 +5,6 @@ namespace Hyde\Framework;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Services\MarkdownFileService;
 
-/**
- * @todo Re-add support for YAML Front Matter.
- */
 class MarkdownPageParser extends AbstractPageParser
 {
     protected string $pageModel = MarkdownPage::class;

--- a/src/MarkdownPostParser.php
+++ b/src/MarkdownPostParser.php
@@ -10,9 +10,9 @@ class MarkdownPostParser extends AbstractPageParser
     protected string $pageModel = MarkdownPost::class;
     protected string $slug;
 
-    public array $matter;
-    public string $body;
     public string $title;
+    public string $body;
+    public array $matter;
 
     public function execute(): void
     {


### PR DESCRIPTION
As a side effect, documentation pages now have support for setting the page title using front matter. However, using front matter in documentation pages, and regular pages, is still completely optional.