### PR TITLE
Allow author array data to be added in front matter

### DIFF
--- a/resources/views/components/post/article.blade.php
+++ b/resources/views/components/post/article.blade.php
@@ -9,8 +9,8 @@
         <h1 itemprop="headline" class="mb-4">{{ $title ?? 'Blog Post' }}</h1>
 		<div id="byline" aria-label="About the post" role="doc-introduction">
             @includeWhen($post->date, 'hyde::components.post.date')
-		    @includeWhen($author, 'hyde::components.post.author')
-            @includeWhen($category, 'hyde::components.post.category')
+		    @includeWhen($post->author, 'hyde::components.post.author')
+            @includeWhen($post->category, 'hyde::components.post.category')
         </div>
     </header>
     @includeWhen(isset($post->image), 'hyde::components.post.image')

--- a/resources/views/components/post/author.blade.php
+++ b/resources/views/components/post/author.blade.php
@@ -1,13 +1,10 @@
-@php
-	$authorObject = Hyde\Framework\Services\AuthorService::find($author);
-@endphp
 by author
 <address itemprop="author" itemscope itemtype="https://schema.org/Person" aria-label="The post author" style="display: inline;"> 
-	@if($authorObject && $authorObject->website)
-	<a href="{{ $authorObject->website }}" rel="author" itemprop="url" aria-label="The author's website">
+	@if($post->author->website)
+	<a href="{{ $post->author->website }}" rel="author" itemprop="url" aria-label="The author's website">
 	@endif
-	<span itemprop="name" aria-label="The author's name" {{ $authorObject && $authorObject->username ? 'title=@'.$authorObject->username.'' : '' }}>{{ $authorObject->name ?? $author }}</span> 
-	@if($authorObject && $authorObject->website)
+	<span itemprop="name" aria-label="The author's name" {{ $post->author->username ? 'title=@'.$post->author->username.'' : '' }}>{{ $post->author->name ?? $post->author->username }}</span> 
+	@if($post->author->website)
 	</a>
 	@endif
 </address> 

--- a/resources/views/components/post/author.blade.php
+++ b/resources/views/components/post/author.blade.php
@@ -3,7 +3,7 @@ by author
 	@if($post->author->website)
 	<a href="{{ $post->author->website }}" rel="author" itemprop="url" aria-label="The author's website">
 	@endif
-	<span itemprop="name" aria-label="The author's name" {{ $post->author->username ? 'title=@'.$post->author->username.'' : '' }}>{{ $post->author->name ?? $post->author->username }}</span> 
+	<span itemprop="name" aria-label="The author's name" {{ ($post->author->username &&  ($post->author->username !== $post->author->name)) ? 'title=@'. urlencode($post->author->username) .'' : '' }}>{{ $post->author->name ?? $post->author->username }}</span> 
 	@if($post->author->website)
 	</a>
 	@endif

--- a/resources/views/components/post/category.blade.php
+++ b/resources/views/components/post/category.blade.php
@@ -1,1 +1,1 @@
-in the category "{{ $category }}"
+in the category "{{ $post->category }}"

--- a/resources/views/layouts/post.blade.php
+++ b/resources/views/layouts/post.blade.php
@@ -2,13 +2,6 @@
 @extends('hyde::layouts.app')
 @section('content')
 
-@php
-$title = $post->matter['title'] ?? false;
-$description = $post->matter['description'] ?? false;
-$category = $post->matter['category'] ?? false;
-$author = $post->matter['author'] ?? false;
-@endphp
-
 @push('meta')
 <!-- Blog Post Meta Tags -->
 @foreach ($post->getMetadata() as $name => $content)

--- a/src/Models/HasAuthor.php
+++ b/src/Models/HasAuthor.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Hyde\Framework\Models;
+
+use Hyde\Framework\Services\AuthorService;
+
+/**
+ * Trait HasAuthor
+ *
+ * @see \Tests\Unit\HasAuthorTest
+ */
+trait HasAuthor
+{
+    public Author $author;
+
+    public function constructAuthor(): void
+    {
+        if (isset($this->matter['author'])) {
+            if (is_string($this->matter['author'])) {
+                $this->author = $this->findAuthor($this->matter['author']);
+            }
+            if (is_array($this->matter['author'])) {
+                $this->author = $this->createAuthor($this->matter['author']);
+            }
+        }
+    }
+
+    protected function findAuthor(string $author): Author
+    {
+        return AuthorService::find($author) ?: new Author($author);
+    }
+
+    protected function createAuthor(array $data): Author
+    {
+        $username = $data['username'] ?? $data['name'] ?? 'Guest';
+        return new Author($username, $data);
+    }
+}

--- a/src/Models/HasMetadata.php
+++ b/src/Models/HasMetadata.php
@@ -44,7 +44,7 @@ trait HasMetadata
 
         // Add author if it exists
         if (isset($this->matter['author'])) {
-            $this->metadata->add('author', $this->matter['author']);
+            $this->metadata->add('author', $this->getAuthor($this->matter['author']));
         }
 
         // Add keywords if it exists
@@ -74,5 +74,14 @@ trait HasMetadata
 
         // If there is an image, add it to the metadata
         // TODO: Add image to metadata
+    }
+
+    protected function getAuthor(string|array $author): string
+    {
+        if (is_string($author)) {
+            return $author;
+        }
+
+        return $author['username'] ?? $author['name'] ?? 'Guest';
     }
 }

--- a/src/Models/MarkdownPost.php
+++ b/src/Models/MarkdownPost.php
@@ -11,6 +11,8 @@ class MarkdownPost extends MarkdownDocument
     use HasDateString;
     use HasFeaturedImage;
 
+    public string $category;
+
     public static string $sourceDirectory = '_posts';
     public static string $parserClass = MarkdownPostParser::class;
 
@@ -22,5 +24,7 @@ class MarkdownPost extends MarkdownDocument
         $this->constructMetadata();
         $this->constructDateString();
         $this->constructFeaturedImage();
+
+        $this->category = $this->matter['category'] ?? '';
     }
 }

--- a/src/Models/MarkdownPost.php
+++ b/src/Models/MarkdownPost.php
@@ -6,6 +6,7 @@ use Hyde\Framework\MarkdownPostParser;
 
 class MarkdownPost extends MarkdownDocument
 {
+    use HasAuthor;
     use HasMetadata;
     use HasDateString;
     use HasFeaturedImage;
@@ -17,6 +18,7 @@ class MarkdownPost extends MarkdownDocument
     {
         parent::__construct($matter, $body, $title, $slug);
 
+        $this->constructAuthor();
         $this->constructMetadata();
         $this->constructDateString();
         $this->constructFeaturedImage();


### PR DESCRIPTION
Before, the only option to add further data to authors for blog posts, for instance a website link, was through the authors.yml config file. You can now set the author data on a per-post basis.

Usage:
```markdown
---
title: Custom Author...
author: 
    username: mr_hyde
    name: Miss Hyde
    website: https://github.com/hydephp
```

Note that custom authors take precedence and will not merge any existing data. For example, if you have a user defined in config that has a website link and display name, and you use the new way to add an author in front matter and only set the display name, the website will be null.
