### PR TITLE
Overhaul the Markdown Converter Service to make it easier to customize and extend

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -31,6 +31,23 @@ return [
 	'extensions' => [
 		\League\CommonMark\Extension\GithubFlavoredMarkdownExtension::class,
 		\League\CommonMark\Extension\Attributes\AttributesExtension::class,
-	]
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Configuration Options
+	|--------------------------------------------------------------------------
+	|
+	| Define any options that should be passed to the CommonMark converter.
+	|
+	| Hyde handles many of the options automatically, but you may want to
+	| override some of them and/or add your own. Any custom options
+	| will be merged with the Hyde defaults during runtime.
+	|
+	*/
+
+	'config' => [
+		//
+	],
 
 ];

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -9,3 +9,28 @@
 | Markdown related services, as well as change the extensions used.
 |
 */
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Markdown Extensions
+	|--------------------------------------------------------------------------
+	|
+	| Define any extra extensions that should be loaded into the CommonMark
+	| converter. Should be fully qualified class names to the extension.
+	|
+	| Remember that you may need to install any third party extensions
+	| through Composer before you can use them.
+	|
+	| Hyde ships with the Github Flavored Markdown extension.
+	| The Torchlight extension is enabled automatically when needed.
+	| 
+	*/
+
+	'extensions' => [
+		\League\CommonMark\Extension\GithubFlavoredMarkdownExtension::class,
+		\League\CommonMark\Extension\Attributes\AttributesExtension::class,
+	]
+
+];

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Markdown Configuration
+|--------------------------------------------------------------------------
+|
+| HydePHP makes heavy use of Markdown. In this file you can configure
+| Markdown related services, as well as change the extensions used.
+|
+*/
+

--- a/src/Actions/ServiceActions/HasConfigurableMarkdownFeatures.php
+++ b/src/Actions/ServiceActions/HasConfigurableMarkdownFeatures.php
@@ -24,6 +24,15 @@ trait HasConfigurableMarkdownFeatures
         return $this;
     }
 
+    public function removeFeature(string $feature): self
+    {
+        if (in_array($feature, $this->features)) {
+            $this->features = array_diff($this->features, [$feature]);
+        }
+
+        return $this;
+    }
+
     public function hasFeature(string $feature): bool
     {
         return in_array($feature, $this->features);

--- a/src/Actions/ServiceActions/HasConfigurableMarkdownFeatures.php
+++ b/src/Actions/ServiceActions/HasConfigurableMarkdownFeatures.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Hyde\Framework\Actions\ServiceActions;
+
+use Hyde\Framework\Features;
+use Hyde\Framework\Markdown;
+use Hyde\Framework\Models\DocumentationPage;
+
+/**
+ * Allow the Markdown service to have configurable features.
+ * @see HasMarkdownFeatures for global feature management.
+ */
+trait HasConfigurableMarkdownFeatures
+{
+    protected array $features = [];
+
+    public function addFeature(string $feature): self
+    {
+        if (!in_array($feature, $this->features)) {
+            $this->features[] = $feature;
+        }
+
+        return $this;
+    }
+
+    public function hasFeature(string $feature): bool
+    {
+        return in_array($feature, $this->features);
+    }
+
+    public function withTableOfContents(): self
+    {
+        $this->addFeature('table-of-contents');
+
+        return $this;
+    }
+
+    public function withPermalinks(): self
+    {
+        $this->addFeature('permalinks');
+
+        return $this;
+    }
+
+    public function canEnablePermalinks(): bool
+    {
+        return $this->hasFeature('permalinks')
+            || $this->sourceModel === DocumentationPage::class && Markdown::hasTableOfContents();
+    }
+
+    public function canEnableTorchlight(): bool
+    {
+        return $this->hasFeature('torchlight') ||
+                    Features::hasTorchlight();
+;
+    }
+}

--- a/src/Actions/ServiceActions/HasMarkdownFeatures.php
+++ b/src/Actions/ServiceActions/HasMarkdownFeatures.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Hyde\Framework\Actions\ServiceActions;
+
+/**
+ * Global Markdown Feature Handler
+ * @see HasConfigurableMarkdownFeatures for per-object configuration
+ */
+trait HasMarkdownFeatures
+{
+    public static function hasTableOfContents(): bool
+    {
+        return config('hyde.documentationPageTableOfContents.enabled', true);
+    }
+}

--- a/src/Actions/ServiceActions/HasTorchlightIntegration.php
+++ b/src/Actions/ServiceActions/HasTorchlightIntegration.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Hyde\Framework\Actions\ServiceActions;
+
+use Hyde\Framework\Features;
+
+trait HasTorchlightIntegration
+{
+    protected bool $useTorchlight;
+    protected bool $torchlightAttribution;
+
+
+    protected function determineIfTorchlightShouldBeEnabled(): bool
+    {
+        return Features::hasTorchlight();
+    }
+
+    protected function determineIfTorchlightAttributionShouldBeInjected(): bool
+    {
+        return $this->useTorchlight && config('torchlight.attribution.enabled', true)
+            && str_contains($this->html, 'Syntax highlighted by torchlight.dev');
+    }
+
+    protected function injectTorchlightAttribution(): string
+    {
+        return $this->converter->convert(config(
+            'torchlight.attribution.markdown',
+            'Syntax highlighted by torchlight.dev'
+        ));
+    }
+}

--- a/src/Actions/ServiceActions/HasTorchlightIntegration.php
+++ b/src/Actions/ServiceActions/HasTorchlightIntegration.php
@@ -9,15 +9,9 @@ trait HasTorchlightIntegration
     protected bool $useTorchlight;
     protected bool $torchlightAttribution;
 
-
-    protected function determineIfTorchlightShouldBeEnabled(): bool
-    {
-        return Features::hasTorchlight();
-    }
-
     protected function determineIfTorchlightAttributionShouldBeInjected(): bool
     {
-        return $this->useTorchlight && config('torchlight.attribution.enabled', true)
+        return config('torchlight.attribution.enabled', true)
             && str_contains($this->html, 'Syntax highlighted by torchlight.dev');
     }
 

--- a/src/Markdown.php
+++ b/src/Markdown.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Hyde\Framework;
+
+use Hyde\Framework\Actions\ServiceActions\HasMarkdownFeatures;
+
+/**
+ * General interface for Markdown services.
+ *
+ * @see \Hyde\Framework\Services\MarkdownConverterService
+ * @method static hasTableOfContents()
+ */
+class Markdown
+{
+    use HasMarkdownFeatures;
+}

--- a/src/Markdown.php
+++ b/src/Markdown.php
@@ -8,8 +8,6 @@ use Hyde\Framework\Actions\ServiceActions\HasMarkdownFeatures;
  * General interface for Markdown services.
  *
  * @see \Hyde\Framework\Services\MarkdownConverterService
- *
- * @method static hasTableOfContents()
  */
 class Markdown
 {

--- a/src/Services/MarkdownConverterService.php
+++ b/src/Services/MarkdownConverterService.php
@@ -32,8 +32,6 @@ class MarkdownConverterService
     {
         $this->sourceModel = $sourceModel;
         $this->markdown = $markdown;
-
-        // Add any default configuration options
     }
 
     public function parse(): string
@@ -83,6 +81,9 @@ class MarkdownConverterService
         foreach (config('markdown.extensions', []) as $extensionClassName) {
             $this->addExtension($extensionClassName);
         }
+
+        // Merge any custom configuration options
+        $this->config = array_merge(config('markdown.config', []), $this->config);
 
         $this->converter = new CommonMarkConverter($this->config);
 

--- a/src/Services/MarkdownConverterService.php
+++ b/src/Services/MarkdownConverterService.php
@@ -2,18 +2,21 @@
 
 namespace Hyde\Framework\Services;
 
-use Hyde\Framework\Features;
+use Hyde\Framework\Actions\ServiceActions\HasTorchlightIntegration;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use Torchlight\Commonmark\V2\TorchlightExtension;
 
+/**
+ * Interface for the CommonMarkConverter,
+ * allowing for easy configuration of extensions.
+ */
 class MarkdownConverterService
 {
-    public string $markdown;
+    use HasTorchlightIntegration;
 
-    protected bool $useTorchlight;
-    protected bool $torchlightAttribution;
+    public string $markdown;
 
     protected CommonMarkConverter $converter;
 
@@ -59,24 +62,5 @@ class MarkdownConverterService
         }
 
         return $this->html;
-    }
-
-    protected function determineIfTorchlightShouldBeEnabled(): bool
-    {
-        return Features::hasTorchlight();
-    }
-
-    protected function determineIfTorchlightAttributionShouldBeInjected(): bool
-    {
-        return $this->useTorchlight && config('torchlight.attribution.enabled', true)
-            && str_contains($this->html, 'Syntax highlighted by torchlight.dev');
-    }
-
-    protected function injectTorchlightAttribution(): string
-    {
-        return $this->converter->convert(config(
-            'torchlight.attribution.markdown',
-            'Syntax highlighted by torchlight.dev'
-        ));
     }
 }

--- a/src/Services/MarkdownConverterService.php
+++ b/src/Services/MarkdownConverterService.php
@@ -5,7 +5,6 @@ namespace Hyde\Framework\Services;
 use Hyde\Framework\Actions\ServiceActions\HasConfigurableMarkdownFeatures;
 use Hyde\Framework\Actions\ServiceActions\HasTorchlightIntegration;
 use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use Torchlight\Commonmark\V2\TorchlightExtension;
 
@@ -33,9 +32,6 @@ class MarkdownConverterService
     {
         $this->sourceModel = $sourceModel;
         $this->markdown = $markdown;
-
-        // Add the default extensions
-        $this->addExtension(GithubFlavoredMarkdownExtension::class);
 
         // Add any default configuration options
     }
@@ -81,6 +77,11 @@ class MarkdownConverterService
 
         if ($this->canEnableTorchlight()) {
             $this->addExtension(TorchlightExtension::class);
+        }
+
+        // Add any custom extensions defined in config
+        foreach (config('markdown.extensions', []) as $extensionClassName) {
+            $this->addExtension($extensionClassName);
         }
 
         $this->converter = new CommonMarkConverter($this->config);

--- a/src/Services/MarkdownConverterService.php
+++ b/src/Services/MarkdownConverterService.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Services;
 
+use Hyde\Framework\Actions\ServiceActions\HasConfigurableMarkdownFeatures;
 use Hyde\Framework\Actions\ServiceActions\HasTorchlightIntegration;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
@@ -11,56 +12,89 @@ use Torchlight\Commonmark\V2\TorchlightExtension;
 /**
  * Interface for the CommonMarkConverter,
  * allowing for easy configuration of extensions.
+ *
+ * @see \Tests\Feature\MarkdownConverterServiceTest
  */
 class MarkdownConverterService
 {
+    use HasConfigurableMarkdownFeatures;
     use HasTorchlightIntegration;
 
     public string $markdown;
+    public ?string $sourceModel = null;
 
+    protected array $config = [];
+    protected array $extensions = [];
     protected CommonMarkConverter $converter;
 
     protected string $html;
 
-    public function __construct(string $markdown, ?bool $useTorchlight = null, ?bool $torchlightAttribution = null)
+    public function __construct(string $markdown, ?string $sourceModel = null)
     {
+        $this->sourceModel = $sourceModel;
         $this->markdown = $markdown;
 
-        $config = [];
-        if (config('hyde.documentationPageTableOfContents.enabled', true)) {
-            $config = array_merge([
+        // Add the default extensions
+        $this->addExtension(GithubFlavoredMarkdownExtension::class);
+
+        // Add any default configuration options
+    }
+
+    public function parse(): string
+    {
+        $this->setupConverter();
+
+        $this->html = $this->converter->convert($this->markdown);
+
+        $this->runPostProcessing();
+
+        return $this->html;
+    }
+
+    public function addExtension(string $extensionClassName): void
+    {
+        if (!in_array($extensionClassName, $this->extensions)) {
+            $this->extensions[] = $extensionClassName;
+        }
+    }
+
+    public function initializeExtension(string $extensionClassName): void
+    {
+        $this->converter->getEnvironment()->addExtension(new $extensionClassName());
+    }
+
+    protected function setupConverter(): void
+    {
+        // Determine what dynamic extensions to enable
+
+        if ($this->canEnablePermalinks()) {
+            $this->addExtension(HeadingPermalinkExtension::class);
+
+            $this->config = array_merge([
                 'heading_permalink' =>[
                     'id_prefix' => '',
                     'fragment_prefix' => '',
                     'symbol' => '',
                 ],
-            ], $config);
+            ], $this->config);
         }
 
-        $this->converter = new CommonMarkConverter($config);
-        $this->converter->getEnvironment()->addExtension(new GithubFlavoredMarkdownExtension());
-
-        if (config('hyde.documentationPageTableOfContents.enabled', true)) {
-            $this->converter->getEnvironment()->addExtension(new HeadingPermalinkExtension());
+        if ($this->canEnableTorchlight()) {
+            $this->addExtension(TorchlightExtension::class);
         }
 
-        $this->useTorchlight = $useTorchlight ?? $this->determineIfTorchlightShouldBeEnabled();
+        $this->converter = new CommonMarkConverter($this->config);
+
+        foreach ($this->extensions as $extension) {
+            $this->initializeExtension($extension);
+        }
     }
 
-    public function parse(): string
+    protected function runPostProcessing(): void
     {
-        if ($this->useTorchlight) {
-            $this->converter->getEnvironment()->addExtension(new TorchlightExtension());
-        }
-
-        $this->html = $this->converter->convert($this->markdown);
-
-        $this->torchlightAttribution = $torchlightAttribution ?? $this->determineIfTorchlightAttributionShouldBeInjected();
-
-        if ($this->torchlightAttribution) {
+        // Run any post-processing actions
+        if ($this->determineIfTorchlightAttributionShouldBeInjected()) {
             $this->html .= $this->injectTorchlightAttribution();
         }
-
-        return $this->html;
     }
 }


### PR DESCRIPTION
Adds a new config that can be used to manage the default CommonMark extensions and add your own. You can also add and override the environment configuration.

Improves the main Markdown Service class by extracting parts into Service-Action Traits, and adding a more programmatic approach where settings can be changed at runtime using method chaining.