### PR TITLE
Fix bugs in article and excerpts not fluently constructing descriptions

### DIFF
--- a/resources/views/components/article-excerpt.blade.php
+++ b/resources/views/components/article-excerpt.blade.php
@@ -15,7 +15,7 @@
 		@isset($post->matter['date'])
 		<span class="opacity-75">
 			<span itemprop="dateCreated datePublished">
-				{{ date('M jS, Y', strtotime($post->matter['date'])) }}</span>,
+				{{ date('M jS, Y', strtotime($post->matter['date'])) }}</span>{{ isset($post->matter['author']) ? ',' : '' }}
 		</span>
 		@endisset
 		@isset($post->matter['author'])

--- a/src/Models/MarkdownPost.php
+++ b/src/Models/MarkdownPost.php
@@ -15,7 +15,7 @@ class MarkdownPost extends MarkdownDocument
     use HasDateString;
     use HasFeaturedImage;
 
-    public string $category;
+    public ?string $category;
 
     public static string $sourceDirectory = '_posts';
     public static string $parserClass = MarkdownPostParser::class;
@@ -29,6 +29,6 @@ class MarkdownPost extends MarkdownDocument
         $this->constructDateString();
         $this->constructFeaturedImage();
 
-        $this->category = $this->matter['category'] ?? '';
+        $this->category = $this->matter['category'] ?? null;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/hydephp/framework/issues/230 by making the $post->category nullable, and https://github.com/hydephp/framework/issues/240 by only adding a comma after the time property if an author is set.