### PR TITLE
Allow documentation sidebar header name to be changed

### DIFF
--- a/config/hyde.php
+++ b/config/hyde.php
@@ -193,6 +193,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Documentation Sidebar Header Name
+    |--------------------------------------------------------------------------
+    |
+    | By default, the sidebar title shown in the documentation page layouts uses
+    | the app name suffixed with "docs". You can change it with this setting.
+    |
+    */
+
+    'docsSidebarHeaderTitle' => config('app.name') . ' Docs',
+
+    /*
+    |--------------------------------------------------------------------------
     | Documentation Site Output Directory
     |--------------------------------------------------------------------------
     |

--- a/resources/views/components/docs/sidebar-header.blade.php
+++ b/resources/views/components/docs/sidebar-header.blade.php
@@ -2,10 +2,11 @@
     <h2 class="font-bold text-gray-700 hover:text-gray-900 dark:text-gray-200 w-fit">
         @if(Hyde::docsIndexPath() !== false)
         <a href="{{ basename(Hyde::docsIndexPath()) }}">
-            {{ config('hyde.name') }} Docs
+            {{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
+
         </a>
         @else
-            {{ config('hyde.name') }} Docs
+            {{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
         @endif
     </h2>
     <div class="ml-auto">


### PR DESCRIPTION
Fixes #233 by implementing the following config section:

```php

  /*
  |--------------------------------------------------------------------------
  | Documentation Sidebar Header Name
  |--------------------------------------------------------------------------
  |
  | By default, the sidebar title shown in the documentation page layouts uses
  | the app name suffixed with "docs". You can change it with this setting.
  |
  */

  'docsSidebarHeaderTitle' => config('app.name') . ' Docs',
```