### PR TITLE
Deprecate filecache.json and related services

### DIFF
--- a/resources/data/README.md
+++ b/resources/data/README.md
@@ -1,3 +1,5 @@
+# @deprecated v0.20.0-dev, see https://github.com/hydephp/framework/issues/243
+
 Info for Hyde Framework package developers:
 
 As of now, this data directory only stores one data file, the filecache.json which contains an index of the default files and their checksums. This file is used as per https://github.com/hydephp/framework/issues/67 to let Hyde know if a default file has been modified by the user or if it is safe to overwrite. Note that the checksums use the md5 hash algorithm which is not cryptographically secure and should not be used for anything other than checking if a file has been modified.

--- a/resources/data/filecacheGenerator.php
+++ b/resources/data/filecacheGenerator.php
@@ -1,6 +1,8 @@
 <?php
 
 /**
+ * @deprecated v0.20.0-dev, see https://github.com/hydephp/framework/issues/243
+ * 
  * @internal Internal devtool to generate a filecache.json file.
  * @usage (cli from the data directory) php filecacheGenerator.php
  */

--- a/src/Commands/HydePublishHomepageCommand.php
+++ b/src/Commands/HydePublishHomepageCommand.php
@@ -86,6 +86,9 @@ class HydePublishHomepageCommand extends Command
         return strstr(str_replace(['<comment>', '</comment>'], '', $choice), ':', true);
     }
 
+    /**
+     * @todo #246 Update to compare with vendor files directly
+     */
     protected function canExistingIndexFileBeOverwritten(): bool
     {
         if (! file_exists(Hyde::path('_pages/index.blade.php')) || $this->option('force')) {

--- a/src/Services/FileCacheService.php
+++ b/src/Services/FileCacheService.php
@@ -6,6 +6,8 @@ use Hyde\Framework\Hyde;
 
 /**
  * Helper methods to interact with the filecache.json file.
+ * 
+ * @deprecated v0.20.0-dev, see https://github.com/hydephp/framework/issues/243
  */
 class FileCacheService
 {

--- a/tests/Unit/FileCacheServiceUnixsumMethodTest.php
+++ b/tests/Unit/FileCacheServiceUnixsumMethodTest.php
@@ -5,6 +5,9 @@ namespace Tests\Unit;
 use Hyde\Framework\Services\FileCacheService as Service;
 use Tests\TestCase;
 
+/**
+ * @deprecated v0.20.0-dev as the service is deprecated, see https://github.com/hydephp/framework/issues/243
+ */
 class FileCacheServiceUnixsumMethodTest extends TestCase
 {
     public function test_method_returns_string()


### PR DESCRIPTION
Instead of having to rely on the filecache.json and ensuring it's up to date, we can just compare files with their vendor counterparts, see #243

Thus, the filecache is being deprecated in the upcoming 0.20.x release.