### PR TITLE
Create .gitattributes, fixes #223

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+* text=auto
+
+*.blade.php diff=html
+*.css diff=css
+*.html diff=html
+*.md diff=markdown
+*.php diff=php
+
+/.github export-ignore
+/bin export-ignore
+/tests export-ignore
+/types export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.styleci.yml export-ignore
+CHANGELOG-* export-ignore
+CODE_OF_CONDUCT.md export-ignore
+CONTRIBUTING.md export-ignore
+docker-compose.yml export-ignore
+phpstan.src.neon.dist export-ignore
+phpstan.types.neon.dist export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
File is "borrowed" from Laravel/Framework, https://github.com/laravel/framework/blob/9.x/.gitattributes