### PR TITLE
Always empty the _site directory when running the static site build command

### DIFF
--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -19,6 +19,8 @@ use LaravelZero\Framework\Commands\Command;
 
 /**
  * Hyde Command to run the Build Process.
+ *
+ * @see \Tests\Feature\Commands\BuildStaticSiteCommandTest
  */
 class HydeBuildStaticSiteCommand extends Command
 {
@@ -34,8 +36,6 @@ class HydeBuildStaticSiteCommand extends Command
         {--run-dev : Run the NPM dev script after build}
         {--run-prod : Run the NPM prod script after build}
         {--pretty : Should the build files be prettified?}
-        {--clean : Should the output directory be emptied before building?}
-        {--force : Allow file deletions when using --clean without confirmation?}
         {--no-api : Disable external API calls, such as Torchlight}';
 
     /**
@@ -60,9 +60,7 @@ class HydeBuildStaticSiteCommand extends Command
 
         $this->printInitialInformation();
 
-        if ($this->handleCleanOption() !== 0) {
-            return 1;
-        }
+        $this->purge();
 
         $this->transferMediaAssets();
 
@@ -117,35 +115,12 @@ class HydeBuildStaticSiteCommand extends Command
         );
     }
 
-    /** @internal */
-    protected function handleCleanOption(): int
-    {
-        if ($this->option('clean')) {
-            if ($this->option('force')) {
-                $this->purge();
-            } else {
-                $this->warn('The --clean option will remove all files in the output directory before building.');
-                if ($this->confirm('Are you sure?')) {
-                    $this->purge();
-                } else {
-                    $this->warn('Aborting.');
-
-                    return 1;
-                }
-            }
-        }
-
-        return 0;
-    }
-
     /**
      * Clear the entire _site directory before running the build.
      *
-     * @internal
-     *
      * @return void
      */
-    public function purge()
+    public function purge(): void
     {
         $this->warn('Removing all files from build directory.');
 
@@ -165,7 +140,7 @@ class HydeBuildStaticSiteCommand extends Command
      *
      * @return void
      */
-    public function postBuildActions()
+    public function postBuildActions(): void
     {
         if ($this->option('pretty')) {
             $this->runNodeCommand(

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -6,6 +6,9 @@ use Hyde\Framework\Actions\CreatesDefaultDirectories;
 use Hyde\Framework\Hyde;
 use Tests\TestCase;
 
+/**
+ * @covers \Hyde\Framework\Commands\HydeBuildStaticSiteCommand
+ */
 class BuildStaticSiteCommandTest extends TestCase
 {
     protected function setUp(): void
@@ -63,23 +66,10 @@ class BuildStaticSiteCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
-    public function test_handle_clean_option()
-    {
-        $this->artisan('build --clean')
-            ->expectsOutput('The --clean option will remove all files in the output directory before building.')
-            ->expectsConfirmation('Are you sure?')
-            ->assertExitCode(1);
-
-        $this->artisan('build --clean')
-            ->expectsOutput('The --clean option will remove all files in the output directory before building.')
-            ->expectsConfirmation('Are you sure?', 'yes')
-            ->assertExitCode(0);
-    }
-
     public function test_handle_purge_method()
     {
         touch(Hyde::path('_site/foo.html'));
-        $this->artisan('build --clean --force')
+        $this->artisan('build')
             ->expectsOutput('Removing all files from build directory.')
             ->expectsOutput(' > Directory purged')
             ->expectsOutput(' > Recreating directories')


### PR DESCRIPTION
It also removes the --clean and --force flag as they are no longer needed.