### PR TITLE
Update HydeFront version to v1.5.x

### DIFF
--- a/src/Services/AssetService.php
+++ b/src/Services/AssetService.php
@@ -12,7 +12,7 @@ class AssetService implements AssetServiceContract
      *
      * @property string $version HydeFront SemVer Tag
      */
-    public string $version = 'v1.4';
+    public string $version = 'v1.5';
 
     public function version(): string
     {


### PR DESCRIPTION
Needed since the internal JS structure has been refactored to use event listeners instead of onclick HTML attributes 