### PR TITLE
Refactor docs layout to use Lagrafo instead of Laradocgen

### DIFF
--- a/resources/views/components/docs/navigation.blade.php
+++ b/resources/views/components/docs/navigation.blade.php
@@ -1,6 +1,7 @@
 <div class="flex flex-row items-center justify-between h-full">
+	<div class="md:hidden">
 	@include('hyde::components.docs.sidebar-header')
-
+	</div>
 	<div class="ml-auto">
         @include('hyde::components.navigation.theme-toggle-button')
     </div>

--- a/resources/views/components/navigation/theme-toggle-button.blade.php
+++ b/resources/views/components/navigation/theme-toggle-button.blade.php
@@ -1,10 +1,6 @@
 @if(Hyde::features('darkmode'))
-<button id="theme-toggle-button" class="flex items-center px-3 py-1 hover:text-gray-700 dark:text-gray-200" aria-label="Toggle dark theme" title="Toggle theme">
-	<svg id="theme-toggle-dark-icon" title="Switch to light theme" class="hidden dark:block" style="width:1.25rem;" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-		<path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path>
-	</svg>
-	<svg id="theme-toggle-light-icon" title="Switch to dark theme" class="block dark:hidden" style="width:1.25rem;" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-		<path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
-	</svg>
+<button class="theme-toggle-button flex items-center px-3 py-1 hover:text-gray-700 dark:text-gray-200" title="Toggle theme">
+	<span class="sr-only">Toggle dark theme</span>
+	<figure class="theme-icon" role="presentation"></figure>
 </button>
 @endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,32 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ config('hyde.language', 'en') }}">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:site_name" content="{{ config('hyde.name', 'HydePHP') }}">
-    <title>{{ isset($title) ? config('hyde.name', 'HydePHP') . ' - ' . $title : config('hyde.name', 'HydePHP') }}</title>
-
-    @if (file_exists(Hyde::path('_media/favicon.ico'))) 
-    <link rel="shortcut icon" href="{{ Hyde::relativePath('media/favicon.ico', $currentPage) }}" type="image/x-icon">
-    @endif
-
-    {{-- Config Defined Tags --}}
-    @foreach (config('hyde.meta', []) as $name => $content) 
-    <meta name="{{ $name }}" content="{{ $content }}">
-    @endforeach
-
-    @stack('meta')
-
-    {{-- App Stylesheets --}}
-    @include('hyde::layouts.styles')
-  
-    {{-- Include any extra tags to include in the <head> section --}}
-    @include('hyde::layouts.meta') 
-
-    @if(Hyde::features('darkmode'))
-    {{-- Check the local storage for theme preference to avoid FOUC --}}
-    <script>if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) { document.documentElement.classList.add('dark'); } else { document.documentElement.classList.remove('dark') } </script>
-    @endif
+    @include('hyde::layouts.head')
 </head>
 <body id="app" class="flex flex-col min-h-screen overflow-x-hidden dark:bg-gray-900 dark:text-white">
     <a href="#content" id="skip-to-content">Skip to content</a>
@@ -38,10 +13,6 @@
 
     @includeUnless(config('hyde.footer.enabled', true) && ($withoutNavigation ?? false), 'hyde::layouts.footer') 
 
-    {{-- App Scripts --}}
     @include('hyde::layouts.scripts') 
-
-    {{-- Include any extra scripts to include before the closing <body> tag --}}
-    @stack('scripts')
 </body>
 </html>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -1,21 +1,87 @@
-{{-- The Documentation Page Layout is based on Laradocgen --}}
-@extends('hyde::layouts.app')
-@section('content')
-@php($withoutNavigation = true)
+<!doctype html>
+<html lang="en">
 
-<nav id="documentation-navigation" class="fixed top-0 w-screen md:w-fit right-0 h-16 p-4 shadow-lg sm:shadow-xl overflow-hidden bg-white dark:bg-gray-800 md:bg-transparent dark:md:bg-transparent md:shadow-none z-30">
-	@include('hyde::components.docs.navigation')
-</nav>
-<aside id="documentation-sidebar" class="w-64 h-screen hidden md:flex flex-col fixed top-0 left-0 shadow-md overflow-hidden bg-white dark:bg-gray-800 z-20">
-	@include('hyde::components.docs.sidebar')
-</aside>
-<main id="documentation-content" class="mx-auto max-w-7xl py-16 px-8 mt-8 md:mt-0 md:absolute md:left-72 xl:left-80">
-	<a name="content" id="content"></a>
-	@include('hyde::components.docs.content')
-</main>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport"
+		content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>{{ isset($title) ? config('hyde.name', 'HydePHP') . ' - ' . $title : config('hyde.name', 'HydePHP') }}
+	</title>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/caendesilva/lagrafo@v0.1.0-beta/dist/lagrafo.min.css">
+</head>
 
-<div id="sidebar-backdrop" title="Click to close sidebar" onClick="hideSidebar()" style="display: none;"></div>
-@if(config('hyde.documentationPageTableOfContents.smoothPageScrolling', true))
-<style> html { scroll-behavior: smooth; } </style>
-@endif
-@endsection
+<body id="lagrafo-app">
+	<script>
+		document.body.classList.add('js-enabled');
+	</script>
+
+	<nav id="mobile-navigation">
+		<strong>
+			@if(Hyde::docsIndexPath() !== false)
+			<a href="{{ basename(Hyde::docsIndexPath()) }}">
+				{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
+			</a>
+			@else
+			{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
+			@endif
+		</strong>
+		<button id="sidebar-toggle" title="Toggle sidebar" aria-label="Toggle sidebar navigation menu">
+			<span class="icon-bar" role="presentation"></span>
+			<span class="icon-bar" role="presentation"></span>
+			<span class="icon-bar" role="presentation"></span>
+			<span class="icon-bar" role="presentation"></span>
+		</button>
+	</nav>
+	<aside id="sidebar">
+		<header id="sidebar-header">
+			<div id="sidebar-brand">
+				<strong>
+					@if(Hyde::docsIndexPath() !== false)
+					<a href="{{ basename(Hyde::docsIndexPath()) }}">
+						{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
+
+					</a>
+					@else
+					{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
+					@endif
+				</strong>
+			</div>
+		</header>
+		<nav id="sidebar-navigation">
+			<ul id="sidebar-navigation-menu" role="list">
+				@foreach (Hyde\Framework\Actions\GeneratesDocumentationSidebar::get($currentPage) as $item)
+				<li @class([ 'sidebar-navigation-item' , 'active'=> $item['active']
+					])>
+					@if($item['active'])
+					<a href="{{ $item['slug'] }}.html" aria-current="true" class="sidebar-navigation-item">{{
+						$item['title'] }}</a>
+
+					@if(isset($docs->tableOfContents))
+					{!! ($docs->tableOfContents) !!}
+					@endif
+					@else
+					<a href="{{ $item['slug'] }}.html" class="sidebar-navigation-item">{{ $item['title'] }}</a>
+					@endif
+				</li>
+				@endforeach
+			</ul>
+		</nav>
+		<footer id="sidebar-footer">
+			<p>
+				<a href="{{ Hyde::relativePath('index.html', $currentPage) }}">Back to home page</a>
+			</p>
+		</footer>
+	</aside>
+	<main id="content">
+		<article id="document" itemscope itemtype="https://schema.org/Article" @class(['mx-auto prose dark:prose-invert
+			max-w-3xl', 'torchlight-enabled'=> Hyde\Framework\Features::hasTorchlight()])>
+			<section id="document-main-content" itemprop="articleBody">
+				{!! $markdown !!}
+			</section>
+		</article>
+	</main>
+	<script defer="" src="https://cdn.jsdelivr.net/gh/caendesilva/lagrafo@v0.1.0-beta/dist/lagrafo.min.js"></script>
+</body>
+
+</html>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -53,14 +53,14 @@
 				<li @class([ 'sidebar-navigation-item' , 'active'=> $item['active']
 					])>
 					@if($item['active'])
-					<a href="{{ $item['slug'] }}.html" aria-current="true" class="sidebar-navigation-item">{{
+					<a href="{{ $item['slug'] }}.html" aria-current="true">{{
 						$item['title'] }}</a>
 
 					@if(isset($docs->tableOfContents))
 					{!! ($docs->tableOfContents) !!}
 					@endif
 					@else
-					<a href="{{ $item['slug'] }}.html" class="sidebar-navigation-item">{{ $item['title'] }}</a>
+					<a href="{{ $item['slug'] }}.html">{{ $item['title'] }}</a>
 					@endif
 				</li>
 				@endforeach

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -40,7 +40,6 @@
 					@if(Hyde::docsIndexPath() !== false)
 					<a href="{{ basename(Hyde::docsIndexPath()) }}">
 						{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
-
 					</a>
 					@else
 					{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
@@ -79,6 +78,13 @@
 			<section id="document-main-content" itemprop="articleBody">
 				{!! $markdown !!}
 			</section>
+			<footer id="document-footer">
+				<nav id="pagination">
+					{{-- NYI --}}
+				</nav>
+	
+				<a href="#">Edit this page</a>
+			</footer>
 		</article>
 	</main>
 	<script defer="" src="https://cdn.jsdelivr.net/gh/caendesilva/lagrafo@v0.1.0-beta/dist/lagrafo.min.js"></script>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -72,13 +72,6 @@
 			<section id="document-main-content" itemprop="articleBody">
 				{!! $markdown !!}
 			</section>
-			<footer id="document-footer">
-				<nav id="pagination">
-					{{-- NYI --}}
-				</nav>
-	
-				<a href="#">Edit this page</a>
-			</footer>
 		</article>
 	</main>
     @include('hyde::layouts.scripts') 

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -39,6 +39,8 @@
 					{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
 					@endif
 				</strong>
+				@include('hyde::components.navigation.theme-toggle-button')
+
 			</div>
 		</header>
 		<nav id="sidebar-navigation">

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -10,7 +10,7 @@
 	</script>
 
 	<nav id="mobile-navigation">
-		<strong>
+		<strong class="mr-auto">
 			@if(Hyde::docsIndexPath() !== false)
 			<a href="{{ basename(Hyde::docsIndexPath()) }}">
 				{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
@@ -19,6 +19,7 @@
 			{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
 			@endif
 		</strong>
+        @include('hyde::components.navigation.theme-toggle-button')
 		<button id="sidebar-toggle" title="Toggle sidebar" aria-label="Toggle sidebar navigation menu">
 			<span class="icon-bar" role="presentation"></span>
 			<span class="icon-bar" role="presentation"></span>
@@ -74,8 +75,7 @@
 			</section>
 		</article>
 	</main>
-    @include('hyde::layouts.scripts') 
-
+    @include('hyde::layouts.scripts')
 	<script defer="" src="https://cdn.jsdelivr.net/gh/caendesilva/lagrafo@v0.1.0-beta/dist/lagrafo.min.js"></script>
 </body>
 </html>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -1,26 +1,9 @@
-<!doctype html>
-<html lang="en">
-
+<!DOCTYPE html>
+<html lang="{{ config('hyde.language', 'en') }}">
 <head>
-	<meta charset="UTF-8">
-	<meta name="viewport"
-		content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>{{ isset($title) ? config('hyde.name', 'HydePHP') . ' - ' . $title : config('hyde.name', 'HydePHP') }}
-	</title>
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/caendesilva/lagrafo@v0.1.0-beta/dist/lagrafo.min.css">
-	<style>
-		#lagrafo-app #sidebar #sidebar-header, #lagrafo-app #sidebar #sidebar-header #sidebar-brand {
-			height: 4rem;
-			display: flex;
-			align-items: center;
-		}
-		#lagrafo-app #sidebar #sidebar-navigation {
-			height: calc(100vh - 8rem);
-		}
-	</style>
+    @include('hyde::layouts.head')
 </head>
-
+	
 <body id="lagrafo-app">
 	<script>
 		document.body.classList.add('js-enabled');
@@ -67,6 +50,7 @@
 						$item['title'] }}</a>
 
 					@if(isset($docs->tableOfContents))
+					<span class="sr-only">Table of contents</span>
 					{!! ($docs->tableOfContents) !!}
 					@endif
 					@else
@@ -83,7 +67,7 @@
 		</footer>
 	</aside>
 	<main id="content">
-		<article id="document" itemscope itemtype="https://schema.org/Article" @class(['mx-auto prose dark:prose-invert
+		<article id="document" itemscope itemtype="https://schema.org/Article" @class(['mx-auto lg:ml-8 prose dark:prose-invert
 			max-w-3xl', 'torchlight-enabled'=> Hyde\Framework\Features::hasTorchlight()])>
 			<section id="document-main-content" itemprop="articleBody">
 				{!! $markdown !!}
@@ -97,7 +81,8 @@
 			</footer>
 		</article>
 	</main>
+    @include('hyde::layouts.scripts') 
+
 	<script defer="" src="https://cdn.jsdelivr.net/gh/caendesilva/lagrafo@v0.1.0-beta/dist/lagrafo.min.js"></script>
 </body>
-
 </html>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -9,6 +9,16 @@
 	<title>{{ isset($title) ? config('hyde.name', 'HydePHP') . ' - ' . $title : config('hyde.name', 'HydePHP') }}
 	</title>
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/caendesilva/lagrafo@v0.1.0-beta/dist/lagrafo.min.css">
+	<style>
+		#lagrafo-app #sidebar #sidebar-header, #lagrafo-app #sidebar #sidebar-header #sidebar-brand {
+			height: 4rem;
+			display: flex;
+			align-items: center;
+		}
+		#lagrafo-app #sidebar #sidebar-navigation {
+			height: calc(100vh - 8rem);
+		}
+	</style>
 </head>
 
 <body id="lagrafo-app">

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 @php($withoutNavigation = true)
 
-<nav id="documentation-navigation" class="md:hidden fixed top-0 w-screen h-16 p-4 shadow-lg sm:shadow-xl overflow-hidden bg-white dark:bg-gray-800 z-30">
+<nav id="documentation-navigation" class="fixed top-0 w-screen md:w-fit right-0 h-16 p-4 shadow-lg sm:shadow-xl overflow-hidden bg-white dark:bg-gray-800 md:bg-transparent dark:md:bg-transparent md:shadow-none z-30">
 	@include('hyde::components.docs.navigation')
 </nav>
 <aside id="documentation-sidebar" class="w-64 h-screen hidden md:flex flex-col fixed top-0 left-0 shadow-md overflow-hidden bg-white dark:bg-gray-800 z-20">

--- a/resources/views/layouts/head.blade.php
+++ b/resources/views/layouts/head.blade.php
@@ -1,0 +1,26 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta property="og:site_name" content="{{ config('hyde.name', 'HydePHP') }}">
+<title>{{ isset($title) ? config('hyde.name', 'HydePHP') . ' - ' . $title : config('hyde.name', 'HydePHP') }}</title>
+
+@if (file_exists(Hyde::path('_media/favicon.ico'))) 
+<link rel="shortcut icon" href="{{ Hyde::relativePath('media/favicon.ico', $currentPage) }}" type="image/x-icon">
+@endif
+
+{{-- Config Defined Tags --}}
+@foreach (config('hyde.meta', []) as $name => $content) 
+<meta name="{{ $name }}" content="{{ $content }}">
+@endforeach
+
+@stack('meta')
+
+{{-- App Stylesheets --}}
+@include('hyde::layouts.styles')
+
+{{-- Include any extra tags to include in the <head> section --}}
+@include('hyde::layouts.meta') 
+
+@if(Hyde::features('darkmode'))
+{{-- Check the local storage for theme preference to avoid FOUC --}}
+<script>if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) { document.documentElement.classList.add('dark'); } else { document.documentElement.classList.remove('dark') } </script>
+@endif

--- a/resources/views/layouts/scripts.blade.php
+++ b/resources/views/layouts/scripts.blade.php
@@ -7,3 +7,6 @@
 @if(Hyde::assetManager()->hasMediaFile('app.js'))
 <script defer src="{{ Hyde::relativeLink('media/app.js', $currentPage) }}"></script>
 @endif
+
+{{-- Include any extra scripts to include before the closing <body> tag --}}
+@stack('scripts')


### PR DESCRIPTION
The frontend for the Hyde documentation module was originally based on Laradocgen, this branch migrates to its successor, Lagrafo. I may keep around the original ("classic") layout for a while; though the Lagrafo port has much better usability.

Fixing both https://github.com/hydephp/framework/issues/236 and https://github.com/hydephp/framework/issues/290.
![localhost_8080_docs_jetstream html(Macbook Pro)](https://user-images.githubusercontent.com/95144705/166987119-a8129986-178e-4652-8152-1596c4c1edee.png)
![localhost_8080_docs_jetstream html(Macbook Pro) (1)](https://user-images.githubusercontent.com/95144705/166987125-f9c85679-562c-4f32-8871-d7e761562f16.png)
![localhost_8080_docs_jetstream html(iPhone 6_7_8)](https://user-images.githubusercontent.com/95144705/166987220-8fe384e3-f3fe-4557-b7e4-8e309438dcdf.png)

