### PR TITLE
Fix #310, allow documentation pages to be hidden from sidebar using front matter

### DIFF
--- a/src/Models/DocumentationSidebarItem.php
+++ b/src/Models/DocumentationSidebarItem.php
@@ -15,12 +15,14 @@ class DocumentationSidebarItem
     public string $label;
     public string $destination;
     public int $priority;
+    public bool $hidden = false;
 
-    public function __construct(string $label, string $destination, ?int $priority = null)
+    public function __construct(string $label, string $destination, ?int $priority = null, bool $hidden = false)
     {
         $this->label = $label;
         $this->destination = $destination;
         $this->priority = $priority ?? $this->findPriorityInConfig($destination);
+        $this->hidden = $hidden;
     }
 
     protected function findPriorityInConfig(string $slug): int
@@ -34,6 +36,11 @@ class DocumentationSidebarItem
         return array_search($slug, $orderIndexArray); //  + 250?
     }
 
+    public function isHidden(): bool
+    {
+        return $this->hidden;
+    }
+
     public static function parseFromFile(string $documentationPageSlug): static
     {
         $matter = YamlFrontMatter::markdownCompatibleParse(
@@ -43,7 +50,8 @@ class DocumentationSidebarItem
         return new static(
             $matter['label'] ?? Hyde::titleFromSlug($documentationPageSlug),
             $documentationPageSlug,
-            $matter['priority'] ?? null
+            $matter['priority'] ?? null,
+            $matter['hidden'] ?? false
         );
     }
 }

--- a/src/Services/DocumentationSidebarService.php
+++ b/src/Services/DocumentationSidebarService.php
@@ -23,7 +23,7 @@ class DocumentationSidebarService implements DocumentationSidebarServiceContract
      */
     public static function get(): DocumentationSidebar
     {
-        return ((new static)->createSidebar()->withoutIndex()->getSidebar()
+        return ((new static)->createSidebar()->withoutIndex()->withoutHidden()->getSidebar()
         )->sortItems()->getCollection();
     }
 
@@ -58,6 +58,18 @@ class DocumentationSidebarService implements DocumentationSidebarServiceContract
     {
         $this->sidebar = $this->sidebar->reject(function (DocumentationSidebarItem $item) {
             return $item->destination === 'index';
+        });
+
+        return $this;
+    }
+
+    /**
+     * Remove hidden files from the sidebar collection.
+     */
+    protected function withoutHidden(): self
+    {
+        $this->sidebar = $this->sidebar->reject(function (DocumentationSidebarItem $item) {
+            return $item->isHidden();
         });
 
         return $this;

--- a/tests/Feature/Services/DocumentationSidebarServiceTest.php
+++ b/tests/Feature/Services/DocumentationSidebarServiceTest.php
@@ -68,6 +68,15 @@ class DocumentationSidebarServiceTest extends TestCase
         $this->assertCount(5, $sidebar);
     }
 
+    public function test_files_with_front_matter_hidden_set_to_true_are_removed_from_sidebar()
+    {
+        $this->createTestFiles();
+        File::put(Hyde::path('_docs/test.md'), "---\nhidden: true\n---\n\n# Foo");
+
+        $sidebar = DocumentationSidebarService::get();
+        $this->assertCount(5, $sidebar);
+    }
+
     public function test_sidebar_is_ordered_alphabetically_when_no_order_is_set_in_config()
     {
         Config::set('hyde.documentationPageOrder', []);


### PR DESCRIPTION
Adding the following to a documentation page will prevent it from showing up in the sidebar, it will however still be compiled.

```markdown
---
hidden: true
---
```