### PR TITLE
Fix #314, add background color fallback to documentation page body

### DIFF
--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -4,7 +4,7 @@
     @include('hyde::layouts.head')
 </head>
 	
-<body id="lagrafo-app">
+<body id="lagrafo-app" class="bg-white dark:bg-gray-900">
 	<script>
 		document.body.classList.add('js-enabled');
 	</script>


### PR DESCRIPTION
Since the main background is loaded in components later in the DOM we need a fallback style for the body element to make sure there is no flicker of white light which can be problematic for people with photosensitive issues

See https://github.com/hydephp/framework/issues/314