### PR TITLE
Refactor post excerpt component to be less reliant on directly using front matter and add view test

### DIFF
--- a/resources/views/components/article-excerpt.blade.php
+++ b/resources/views/components/article-excerpt.blade.php
@@ -1,42 +1,47 @@
+@php
+/** @var \Hyde\Framework\Models\MarkdownPost $post */
+@endphp
+
 <article class="mt-4 mb-8" itemscope itemtype="https://schema.org/Article">
     <meta itemprop="identifier" content="{{ $post->slug }}">
-	@if(Hyde::uriPath())
+@if(Hyde::uriPath())
     <meta itemprop="url" content="{{ Hyde::uriPath('posts/' . $post->slug) }}">
-    @endif
+@endif
     
 	<header>
-		<a href="posts/{{ $post->matter['slug'] }}.html" class="block w-fit">
+		<a href="posts/{{ $post->slug }}.html" class="block w-fit">
 			<h2 class="text-2xl font-bold text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white transition-colors duration-75">
 				{{ $post->matter['title'] ?? $post->title }}
 			</h2>
 		</a>
 	</header>
+
 	<footer>
-		@isset($post->matter['date'])
+@isset($post->matter['date'])
 		<span class="opacity-75">
 			<span itemprop="dateCreated datePublished">
 				{{ date('M jS, Y', strtotime($post->matter['date'])) }}</span>{{ isset($post->matter['author']) ? ',' : '' }}
 		</span>
-		@endisset
-		@isset($post->matter['author'])
+@endisset
+@isset($post->author)
 		<span itemprop="author" itemscope itemtype="https://schema.org/Person">
 			<span class="opacity-75">by</span>
 			<span itemprop="name">
-				{{ $post->matter['author'] }}
+				{{ $post->author->name ?? $post->author->username }}
 			</span>
 		</span>
-		@endisset
+@endisset
 	</footer>
 	
-	<div>
-		@isset($post->matter['description'])
-		<section role="doc-abstract" aria-label="Excerpt">
-			<p class="leading-relaxed my-1">
-				{{ $post->matter['description'] }}
-			</p>
-		</section>
-		@endisset
-			
-		<a href="posts/{{ $post->matter['slug'] }}.html" class="text-indigo-500 hover:underline font-medium">Read post</a>
-	</div>	
+@isset($post->matter['description'])
+	<section role="doc-abstract" aria-label="Excerpt">
+		<p class="leading-relaxed my-1">
+			{{ $post->matter['description'] }}
+		</p>
+	</section>
+@endisset
+
+	<footer>
+		<a href="posts/{{ $post->slug }}.html" class="text-indigo-500 hover:underline font-medium">Read post</a>
+	</footer>
 </article>

--- a/resources/views/components/article-excerpt.blade.php
+++ b/resources/views/components/article-excerpt.blade.php
@@ -17,10 +17,10 @@
 	</header>
 
 	<footer>
-@isset($post->matter['date'])
+@isset($post->date)
 		<span class="opacity-75">
 			<span itemprop="dateCreated datePublished">
-				{{ date('M jS, Y', strtotime($post->matter['date'])) }}</span>{{ isset($post->matter['author']) ? ',' : '' }}
+				{{ $post->date->short }}</span>{{ isset($post->author) ? ',' : '' }}
 		</span>
 @endisset
 @isset($post->author)

--- a/tests/Unit/Views/ArticleExcerptViewTest.php
+++ b/tests/Unit/Views/ArticleExcerptViewTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Views;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\MarkdownPost;
+use Illuminate\Support\Facades\Blade;
+use Tests\TestCase;
+
+/**
+ * @see resources/views/components/article-excerpt.blade.php
+ */
+class ArticleExcerptViewTest extends TestCase
+{
+    protected function renderTestView(MarkdownPost $post): string
+    {
+        return Blade::render(file_get_contents(
+            Hyde::vendorPath('resources/views/components/article-excerpt.blade.php')
+        ), ['post' => $post]);
+    }
+
+	public function test_component_can_be_rendered()
+	{
+        $view = $this->renderTestView(new MarkdownPost([], ''));
+        $this->assertStringContainsString('https://schema.org/Article', $view);
+	}
+
+    public function test_component_renders_post_data()
+    {
+        $view = $this->renderTestView(new MarkdownPost([
+            'title' => 'Test Post',
+            'date' => '2022-01-01 12:00:00',
+            'author' => 'John Doe',
+            'description' => 'This is a test post.',
+        ], '# Foo Bar', 'Foo Bar', 'foo-bar'));
+
+        $this->assertStringContainsString('Test Post', $view);
+        $this->assertStringContainsString('Jan 1st, 2022', $view);
+        $this->assertStringContainsString('John Doe', $view);
+        $this->assertStringContainsString('This is a test post.', $view);
+        $this->assertStringContainsString('Read post', $view);
+    }
+
+    public function test_component_renders_post_with_author_object()
+    {
+        $view = $this->renderTestView(new MarkdownPost([
+            'author' => [
+                'name' => 'John Doe',
+                'url' => '#',
+            ],
+        ], ''));
+
+        $this->assertStringContainsString('John Doe', $view);
+    }
+}

--- a/tests/Unit/Views/ArticleExcerptViewTest.php
+++ b/tests/Unit/Views/ArticleExcerptViewTest.php
@@ -52,4 +52,24 @@ class ArticleExcerptViewTest extends TestCase
 
         $this->assertStringContainsString('John Doe', $view);
     }
+
+	public function test_there_is_no_comma_after_date_string_when_there_is_no_author()
+	{
+        $view = $this->renderTestView(new MarkdownPost([
+			'date' => '2022-01-01',
+		], ''));
+
+		$this->assertStringContainsString('Jan 1st, 2022</span>', $view);
+		$this->assertStringNotContainsString('Jan 1st, 2022</span>,', $view);
+	}
+
+	public function test_there_is_a_comma_after_date_string_when_there_is_a_author()
+	{
+		 $view = $this->renderTestView(new MarkdownPost([
+			'date' => '2022-01-01',
+			'author' => 'John Doe',
+		], ''));
+
+        $this->assertStringContainsString('Jan 1st, 2022</span>,', $view);
+	}
 }


### PR DESCRIPTION
The component was pretty outdated and was referencing front matter directly. This this PR refactors the component to use the Author and DateString models.

Fixes #306 bug in article excerpt where author name uses front matter directly causing exception