### PR TITLE
#153 Fix bug where config option uses app name instead of Hyde name.

### DIFF
--- a/config/hyde.php
+++ b/config/hyde.php
@@ -29,9 +29,12 @@ return [
     | This value sets the name of your site and is, for example, used in
     | the compiled page titles and more. The default value is HydePHP.
     |
+    | The name is stored in the $siteName variable so it can be
+    | used again later on in this config.
+    |
     */
 
-    'name' => env('SITE_NAME', 'HydePHP'),
+    'name' => $siteName = env('SITE_NAME', 'HydePHP'),
 
     /*
     |--------------------------------------------------------------------------
@@ -201,7 +204,7 @@ return [
     |
     */
 
-    'docsSidebarHeaderTitle' => config('app.name').' Docs',
+    'docsSidebarHeaderTitle' => $siteName.' Docs',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Fixes it by implementing a local variable that stores the configured Hyde site name so it can be reused later.

