### PR TITLE
Add documentation sidebar category labels, fixes #309

### DIFF
--- a/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
+++ b/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
@@ -1,0 +1,25 @@
+<ul id="sidebar-navigation-menu" role="list">
+	@foreach (Hyde\Framework\Services\DocumentationSidebarService::getCategories() as $category)
+	<li role="listitem">
+		<h4>{{ Hyde::titleFromSlug($category) }}</h4>
+		<ul role="list">
+			@foreach (Hyde\Framework\Services\DocumentationSidebarService::getItemsInCategory($category) as $item)
+			<li @class([ 'sidebar-navigation-item' , 'active'=> $item->destination === basename($currentPage)]) role="listitem">
+				@if($item->destination === basename($currentPage))
+				<a href="{{ $item->destination }}.html" aria-current="true">{{
+					$item->label }}</a>
+		
+				@if(isset($docs->tableOfContents))
+				<span class="sr-only">Table of contents</span>
+				{!! ($docs->tableOfContents) !!}
+				@endif
+				@else
+				<a href="{{ $item->destination }}.html">{{ $item->label }}</a>
+				@endif
+			</li role="listitem">
+			@endforeach
+		</ul>
+	</li>
+	@endforeach
+
+</ul>

--- a/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
+++ b/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
@@ -1,9 +1,9 @@
 <ul id="sidebar-navigation-menu" role="list">
-	@foreach (Hyde\Framework\Services\DocumentationSidebarService::getCategories() as $category)
+	@foreach ($sidebar->getCategories() as $category)
 	<li role="listitem">
 		<h4>{{ Hyde::titleFromSlug($category) }}</h4>
 		<ul role="list">
-			@foreach (Hyde\Framework\Services\DocumentationSidebarService::getItemsInCategory($category) as $item)
+			@foreach ($sidebar->getItemsInCategory($category) as $item)
 			<li @class([ 'sidebar-navigation-item' , 'active'=> $item->destination === basename($currentPage)]) role="listitem">
 				@if($item->destination === basename($currentPage))
 				<a href="{{ $item->destination }}.html" aria-current="true">{{

--- a/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
+++ b/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
@@ -1,14 +1,12 @@
 <ul id="sidebar-navigation-menu" role="list">
 	@foreach ($sidebar->getCategories() as $category)
-	<li role="listitem">
-		<h4>{{ Hyde::titleFromSlug($category) }}</h4>
-		<ul role="list">
+	<li class="sidebar-category" role="listitem">
+		<h4 class="sidebar-category-heading">{{ Hyde::titleFromSlug($category) }}</h4>
+		<ul class="sidebar-category-list" role="list">
 			@foreach ($sidebar->getItemsInCategory($category) as $item)
 			<li @class([ 'sidebar-navigation-item' , 'active'=> $item->destination === basename($currentPage)]) role="listitem">
 				@if($item->destination === basename($currentPage))
-				<a href="{{ $item->destination }}.html" aria-current="true">{{
-					$item->label }}</a>
-		
+				<a href="{{ $item->destination }}.html" aria-current="true">{{ $item->label }}</a>
 				@if(isset($docs->tableOfContents))
 				<span class="sr-only">Table of contents</span>
 				{!! ($docs->tableOfContents) !!}
@@ -21,5 +19,36 @@
 		</ul>
 	</li>
 	@endforeach
-
 </ul>
+
+<style>
+	/* Style the sidebar layout for sidebars with categories */
+	/* Inline styles until PR is ready, @todo merge into HydeFront */
+	.sidebar-category {
+		margin-top: 1rem;
+		margin-bottom: 1rem;
+	}
+	.sidebar-category-heading {
+		font-size: 1rem;
+		font-weight: 600;
+		margin-bottom: 0.5rem;
+		margin-left: -0.25rem;
+	}
+	.sidebar-category-list {
+		margin-left: 1rem;
+	}
+	
+	#lagrafo-app #sidebar #sidebar-navigation .sidebar-category-list .sidebar-navigation-item.active {
+		margin-left: -2rem;
+    	padding-left: 2rem;
+	}
+	#lagrafo-app #sidebar #sidebar-navigation .sidebar-category-list .sidebar-navigation-item > a {
+		margin-left: -2rem;
+    	padding-left: 1rem;
+		/* Decrease vertical spacing for a more compact layout */
+		padding-top: 0.2rem;
+		padding-bottom: 0.2rem;
+		margin-top: 0.2rem;
+		margin-bottom: 0.2rem;
+	}
+</style>

--- a/resources/views/components/docs/sidebar-navigation-menu.blade.php
+++ b/resources/views/components/docs/sidebar-navigation-menu.blade.php
@@ -1,5 +1,5 @@
 <ul id="sidebar-navigation-menu" role="list">
-	@foreach (Hyde\Framework\Services\DocumentationSidebarService::get() as $item)
+	@foreach ($sidebar->getSidebar() as $item)
 	<li @class([ 'sidebar-navigation-item' , 'active'=> $item->destination === basename($currentPage)])>
 		@if($item->destination === basename($currentPage))
 		<a href="{{ $item->destination }}.html" aria-current="true">{{

--- a/resources/views/components/docs/sidebar-navigation-menu.blade.php
+++ b/resources/views/components/docs/sidebar-navigation-menu.blade.php
@@ -1,0 +1,17 @@
+<ul id="sidebar-navigation-menu" role="list">
+	@foreach (Hyde\Framework\Services\DocumentationSidebarService::get() as $item)
+	<li @class([ 'sidebar-navigation-item' , 'active'=> $item->destination === basename($currentPage)])>
+		@if($item->destination === basename($currentPage))
+		<a href="{{ $item->destination }}.html" aria-current="true">{{
+			$item->label }}</a>
+
+		@if(isset($docs->tableOfContents))
+		<span class="sr-only">Table of contents</span>
+		{!! ($docs->tableOfContents) !!}
+		@endif
+		@else
+		<a href="{{ $item->destination }}.html">{{ $item->label }}</a>
+		@endif
+	</li>
+	@endforeach
+</ul>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -45,7 +45,11 @@
 			</div>
 		</header>
 		<nav id="sidebar-navigation">
+			@if(Hyde\Framework\Services\DocumentationSidebarService::hasCategories())
+			@include('hyde::components.docs.labeled-sidebar-navigation-menu')
+			@else
 			@include('hyde::components.docs.sidebar-navigation-menu')
+			@endif
 		</nav>
 		<footer id="sidebar-footer">
 			<p>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -45,23 +45,7 @@
 			</div>
 		</header>
 		<nav id="sidebar-navigation">
-			<ul id="sidebar-navigation-menu" role="list">
-				@foreach (Hyde\Framework\Services\DocumentationSidebarService::get() as $item)
-				<li @class([ 'sidebar-navigation-item' , 'active'=> $item->destination === basename($currentPage)])>
-					@if($item->destination === basename($currentPage))
-					<a href="{{ $item->destination }}.html" aria-current="true">{{
-						$item->label }}</a>
-
-					@if(isset($docs->tableOfContents))
-					<span class="sr-only">Table of contents</span>
-					{!! ($docs->tableOfContents) !!}
-					@endif
-					@else
-					<a href="{{ $item->destination }}.html">{{ $item->label }}</a>
-					@endif
-				</li>
-				@endforeach
-			</ul>
+			@include('hyde::components.docs.sidebar-navigation-menu')
 		</nav>
 		<footer id="sidebar-footer">
 			<p>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -45,7 +45,11 @@
 			</div>
 		</header>
 		<nav id="sidebar-navigation">
-			@if(Hyde\Framework\Services\DocumentationSidebarService::hasCategories())
+			@php
+				$sidebar = Hyde\Framework\Services\DocumentationSidebarService::create();
+			@endphp
+
+			@if($sidebar->hasCategories())
 			@include('hyde::components.docs.labeled-sidebar-navigation-menu')
 			@else
 			@include('hyde::components.docs.sidebar-navigation-menu')

--- a/src/Concerns/HasDocumentationSidebarCategories.php
+++ b/src/Concerns/HasDocumentationSidebarCategories.php
@@ -23,13 +23,15 @@ trait HasDocumentationSidebarCategories
     {
         $this->assembleCategories();
 
+        // Todo sort by priority
         return $this->categories;
     }
 
     public function getItemsInCategory(string $category): DocumentationSidebar
     {
-        // @todo: Implement getItemsInCategory() method.
-        return new DocumentationSidebar();
+        return $this->sidebar->filter(function ($item) use ($category) {
+            return $item->category === $category;
+        });
     }
 
     protected function assembleCategories(): void

--- a/src/Concerns/HasDocumentationSidebarCategories.php
+++ b/src/Concerns/HasDocumentationSidebarCategories.php
@@ -10,21 +10,37 @@ use Hyde\Framework\Models\DocumentationSidebar;
  */
 trait HasDocumentationSidebarCategories
 {
+    protected array $categories = [];
+
     public function hasCategories(): bool
     {
-        // @todo: Implement hasCategories() method.
-        return false;
+        $this->assembleCategories();
+
+        return !empty($this->categories);
     }
 
     public function getCategories(): array
     {
-        // @todo: Implement getCategories() method.
-        return [];
+        $this->assembleCategories();
+
+        return $this->categories;
     }
 
     public function getItemsInCategory(string $category): DocumentationSidebar
     {
         // @todo: Implement getItemsInCategory() method.
         return new DocumentationSidebar();
+    }
+
+    protected function assembleCategories(): void
+    {
+        foreach ($this->sidebar as $item) {
+            if (isset($item->category)) {
+                // Add to the categories array if it doesn't exist.
+                if (! in_array($item->category, $this->categories)) {
+                    $this->categories[] = $item->category;
+                }
+            }
+        }
     }
 }

--- a/src/Concerns/HasDocumentationSidebarCategories.php
+++ b/src/Concerns/HasDocumentationSidebarCategories.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Concerns;
 
 use Hyde\Framework\Models\DocumentationSidebar;
+use Illuminate\Support\Str;
 
 /**
  * Extracts logic for the sidebar categories used in the SidebarService.
@@ -29,7 +30,7 @@ trait HasDocumentationSidebarCategories
     public function getItemsInCategory(string $category): DocumentationSidebar
     {
         return $this->sidebar->filter(function ($item) use ($category) {
-            return $item->category === $category;
+            return $item->category === Str::slug($category);
         });
     }
 

--- a/src/Concerns/HasDocumentationSidebarCategories.php
+++ b/src/Concerns/HasDocumentationSidebarCategories.php
@@ -23,7 +23,6 @@ trait HasDocumentationSidebarCategories
     {
         $this->assembleCategories();
 
-        // Todo sort by priority
         return $this->categories;
     }
 
@@ -44,5 +43,7 @@ trait HasDocumentationSidebarCategories
                 }
             }
         }
+
+        // Todo sort by priority
     }
 }

--- a/src/Concerns/HasDocumentationSidebarCategories.php
+++ b/src/Concerns/HasDocumentationSidebarCategories.php
@@ -56,9 +56,11 @@ trait HasDocumentationSidebarCategories
         foreach ($this->sidebar as $item) {
             if (! isset($item->category)) {
                 $item->category = 'other';
+
+                if (! in_array('other', $this->categories)) {
+                    $this->categories[] = 'other';
+                }
             }
         }
-
-        $this->categories[] = 'other';
     }
 }

--- a/src/Concerns/HasDocumentationSidebarCategories.php
+++ b/src/Concerns/HasDocumentationSidebarCategories.php
@@ -37,13 +37,27 @@ trait HasDocumentationSidebarCategories
     {
         foreach ($this->sidebar as $item) {
             if (isset($item->category)) {
-                // Add to the categories array if it doesn't exist.
                 if (! in_array($item->category, $this->categories)) {
                     $this->categories[] = $item->category;
                 }
             }
         }
 
+        if (! empty($this->categories)) {
+            $this->setCategoryOfUncategorizedItems();
+        }
+
         // Todo sort by priority
+    }
+    
+    protected function setCategoryOfUncategorizedItems(): void
+    {
+        foreach ($this->sidebar as $item) {
+            if (! isset($item->category)) {
+                $item->category = 'other';
+            }
+        }
+
+        $this->categories[] = 'other';
     }
 }

--- a/src/Concerns/HasDocumentationSidebarCategories.php
+++ b/src/Concerns/HasDocumentationSidebarCategories.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Hyde\Framework\Concerns;
+
+use Hyde\Framework\Models\DocumentationSidebar;
+
+/**
+ * Extracts logic for the sidebar categories used in the SidebarService.
+ * @see \Hyde\Framework\Services\DocumentationSidebarService
+ */
+trait HasDocumentationSidebarCategories
+{
+    public function hasCategories(): bool
+    {
+        // @todo: Implement hasCategories() method.
+        return false;
+    }
+
+    public function getCategories(): array
+    {
+        // @todo: Implement getCategories() method.
+        return [];
+    }
+
+    public function getItemsInCategory(string $category): DocumentationSidebar
+    {
+        // @todo: Implement getItemsInCategory() method.
+        return new DocumentationSidebar();
+    }
+}

--- a/src/Models/DocumentationSidebarItem.php
+++ b/src/Models/DocumentationSidebarItem.php
@@ -24,7 +24,7 @@ class DocumentationSidebarItem
         $this->label = $label;
         $this->destination = $destination;
         $this->priority = $priority ?? $this->findPriorityInConfig($destination);
-        $this->category = empty($category) ? null : Str::slug($category);
+        $this->category = $this->normalizeCategoryKey($category);
         $this->hidden = $hidden;
     }
 
@@ -57,5 +57,10 @@ class DocumentationSidebarItem
             $matter['category'] ?? null,
             $matter['hidden'] ?? false
         );
+    }
+
+    protected function normalizeCategoryKey(?string $category): ?string
+    {
+        return empty($category) ? null : Str::slug($category);
     }
 }

--- a/src/Models/DocumentationSidebarItem.php
+++ b/src/Models/DocumentationSidebarItem.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Models;
 
 use Hyde\Framework\Hyde;
+use Illuminate\Support\Str;
 use Spatie\YamlFrontMatter\YamlFrontMatter;
 
 /**
@@ -23,7 +24,7 @@ class DocumentationSidebarItem
         $this->label = $label;
         $this->destination = $destination;
         $this->priority = $priority ?? $this->findPriorityInConfig($destination);
-        $this->category = $category;
+        $this->category = empty($category) ? null : Str::slug($category);
         $this->hidden = $hidden;
     }
 

--- a/src/Models/DocumentationSidebarItem.php
+++ b/src/Models/DocumentationSidebarItem.php
@@ -16,12 +16,14 @@ class DocumentationSidebarItem
     public string $destination;
     public int $priority;
     public bool $hidden = false;
+    public ?string $category = null;
 
-    public function __construct(string $label, string $destination, ?int $priority = null, bool $hidden = false)
+    public function __construct(string $label, string $destination, ?int $priority = null, ?string $category = null, bool $hidden = false)
     {
         $this->label = $label;
         $this->destination = $destination;
         $this->priority = $priority ?? $this->findPriorityInConfig($destination);
+        $this->category = $category;
         $this->hidden = $hidden;
     }
 
@@ -51,6 +53,7 @@ class DocumentationSidebarItem
             $matter['label'] ?? Hyde::titleFromSlug($documentationPageSlug),
             $documentationPageSlug,
             $matter['priority'] ?? null,
+            $matter['category'] ?? null,
             $matter['hidden'] ?? false
         );
     }

--- a/src/Services/DocumentationSidebarService.php
+++ b/src/Services/DocumentationSidebarService.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Services;
 
+use Hyde\Framework\Concerns\HasDocumentationSidebarCategories;
 use Hyde\Framework\Contracts\DocumentationSidebarServiceContract;
 use Hyde\Framework\Models\DocumentationSidebar;
 use Hyde\Framework\Models\DocumentationSidebarItem;
@@ -13,6 +14,8 @@ use Hyde\Framework\Models\DocumentationSidebarItem;
  */
 class DocumentationSidebarService implements DocumentationSidebarServiceContract
 {
+    use HasDocumentationSidebarCategories;
+
     /**
      * The sidebar object created and managed by the service instance.
      */

--- a/src/Services/DocumentationSidebarService.php
+++ b/src/Services/DocumentationSidebarService.php
@@ -22,12 +22,19 @@ class DocumentationSidebarService implements DocumentationSidebarServiceContract
     protected DocumentationSidebar $sidebar;
 
     /**
+     * Shorthand to create a new Sidebar service using default methods.
+     */
+    public static function create(): static
+    {
+        return ((new static)->createSidebar()->withoutIndex()->withoutHidden());
+    }
+
+    /**
      * Shorthand to create a new Sidebar object using default methods.
      */
     public static function get(): DocumentationSidebar
     {
-        return ((new static)->createSidebar()->withoutIndex()->withoutHidden()->getSidebar()
-        )->sortItems()->getCollection();
+        return static::create()->getSidebar()->sortItems()->getCollection();
     }
 
     /**

--- a/src/Services/DocumentationSidebarService.php
+++ b/src/Services/DocumentationSidebarService.php
@@ -55,6 +55,16 @@ class DocumentationSidebarService implements DocumentationSidebarServiceContract
     }
 
     /**
+     * Add an item to the sidebar collection.
+     */
+    public function addItem(DocumentationSidebarItem $item): self
+    {
+        $this->sidebar->addItem($item);
+
+        return $this;
+    }
+
+    /**
      * Remove the index page from the sidebar collection.
      */
     protected function withoutIndex(): self

--- a/tests/Feature/Services/DocumentationSidebarServiceTest.php
+++ b/tests/Feature/Services/DocumentationSidebarServiceTest.php
@@ -191,6 +191,22 @@ class DocumentationSidebarServiceTest extends TestCase
         $this->assertTrue($service->hasCategories());
     }
 
+    public function test_get_items_in_category_returns_items_with_given_category()
+    {
+        $service = (new DocumentationSidebarService)->createSidebar();
+    
+        $service->addItem($foo = new DocumentationSidebarItem('foo', 'foo', category: 'foo'));
+        $service->addItem(new DocumentationSidebarItem('bar', 'bar', category: 'foo'));
+        $service->addItem(new DocumentationSidebarItem('cat', 'cat', category: 'cat'));
+        $service->addItem(new DocumentationSidebarItem('hat', 'hat'));
+
+        $this->assertCount(2, $service->getItemsInCategory('foo'));
+        $this->assertCount(1, $service->getItemsInCategory('cat'));
+        $this->assertCount(0, $service->getItemsInCategory('hat'));
+
+        $this->assertEquals($foo, $service->getItemsInCategory('foo')->first());
+    }
+
     protected function resetDocsDirectory(): void
     {
         File::deleteDirectory(Hyde::path('_docs'));

--- a/tests/Feature/Services/DocumentationSidebarServiceTest.php
+++ b/tests/Feature/Services/DocumentationSidebarServiceTest.php
@@ -171,7 +171,7 @@ class DocumentationSidebarServiceTest extends TestCase
         $service->addItem(new DocumentationSidebarItem('cat', 'cat', category: 'cat'));
         $service->addItem(new DocumentationSidebarItem('hat', 'hat'));
 
-        $this->assertEquals(['foo', 'cat'], $service->getCategories());
+        $this->assertEquals(['foo', 'cat', 'other'], $service->getCategories());
     }
 
     public function test_has_categories_returns_false_if_no_categories_are_set()
@@ -206,6 +206,37 @@ class DocumentationSidebarServiceTest extends TestCase
 
         $this->assertEquals($foo, $service->getItemsInCategory('foo')->first());
     }
+
+    public function test_items_with_no_category_gets_added_to_the_default_category_when_at_least_one_category_is_set()
+    {
+        $service = DocumentationSidebarService::create();
+
+        $service->addItem(new DocumentationSidebarItem('foo', 'foo', category: 'foo'));
+        $service->addItem(new DocumentationSidebarItem('bar', 'bar'));
+
+        $categories = $service->getCategories();
+
+        $this->assertCount(2, $categories);
+        $this->assertCount(1, $service->getItemsInCategory('foo'));
+        $this->assertCount(1, $service->getItemsInCategory('other'));
+        $this->assertEquals('foo', $service->getItemsInCategory('foo')->first()->category);
+        $this->assertEquals('other', $service->getItemsInCategory('other')->first()->category);
+    }
+
+    public function test_items_with_no_category_gets_added_to_the_default_category_when_no_categories_are_set()
+    {
+        $service = DocumentationSidebarService::create();
+        $service->addItem(new DocumentationSidebarItem('foo', 'foo'));
+        $service->addItem(new DocumentationSidebarItem('bar', 'bar'));
+
+        $categories = $service->getCategories();
+
+        $this->assertCount(0, $categories);
+    }
+    
+
+
+
 
     protected function resetDocsDirectory(): void
     {

--- a/tests/Feature/Services/DocumentationSidebarServiceTest.php
+++ b/tests/Feature/Services/DocumentationSidebarServiceTest.php
@@ -234,9 +234,17 @@ class DocumentationSidebarServiceTest extends TestCase
         $this->assertCount(0, $categories);
     }
     
+    public function test_category_names_are_case_insensitive()
+    {
+        $service = DocumentationSidebarService::create();
+        $service->addItem(new DocumentationSidebarItem('foo', 'foo', category: 'Foo Bar'));
+        $service->addItem(new DocumentationSidebarItem('bar', 'bar', category: 'foo bar'));
+        $service->addItem(new DocumentationSidebarItem('cat', 'cat', category: 'Foo_bar'));
+        $categories = $service->getCategories();
 
-
-
+        $this->assertCount(1, $categories);
+        $this->assertCount(3, $service->getItemsInCategory('foo bar'));
+    }
 
     protected function resetDocsDirectory(): void
     {

--- a/tests/Feature/Services/DocumentationSidebarServiceTest.php
+++ b/tests/Feature/Services/DocumentationSidebarServiceTest.php
@@ -163,6 +163,34 @@ class DocumentationSidebarServiceTest extends TestCase
         $this->assertEquals('bar', DocumentationSidebarService::get()->first()->category);
     }
 
+    public function test_sidebar_categories_are_assembled_from_sidebar_items()
+    {
+        $service = (new DocumentationSidebarService)->createSidebar();
+        $service->addItem(new DocumentationSidebarItem('foo', 'foo', category: 'foo'));
+        $service->addItem(new DocumentationSidebarItem('bar', 'bar', category: 'foo'));
+        $service->addItem(new DocumentationSidebarItem('cat', 'cat', category: 'cat'));
+        $service->addItem(new DocumentationSidebarItem('hat', 'hat'));
+
+        $this->assertEquals(['foo', 'cat'], $service->getCategories());
+    }
+
+    public function test_has_categories_returns_false_if_no_categories_are_set()
+    {
+        $service = (new DocumentationSidebarService)->createSidebar();
+        $service->addItem(new DocumentationSidebarItem('foo', 'foo'));
+
+        $this->assertFalse($service->hasCategories());
+    }
+
+    public function test_has_categories_returns_true_if_at_least_one_category_is_set()
+    {
+        $service = (new DocumentationSidebarService)->createSidebar();
+        $service->addItem(new DocumentationSidebarItem('foo', 'foo', category: 'foo'));
+        $service->addItem(new DocumentationSidebarItem('bar', 'bar'));
+
+        $this->assertTrue($service->hasCategories());
+    }
+
     protected function resetDocsDirectory(): void
     {
         File::deleteDirectory(Hyde::path('_docs'));

--- a/tests/Feature/Services/DocumentationSidebarServiceTest.php
+++ b/tests/Feature/Services/DocumentationSidebarServiceTest.php
@@ -150,6 +150,19 @@ class DocumentationSidebarServiceTest extends TestCase
         $this->assertEquals('third', $sidebar[2]->destination);
     }
 
+    public function test_category_can_be_set_in_front_matter()
+    {
+        file_put_contents(
+            Hyde::path('_docs/foo.md'),
+                (new ConvertsArrayToFrontMatter)->execute([
+                'category' => 'bar',
+            ])
+        );
+
+        $this->assertEquals('bar', DocumentationSidebarItem::parseFromFile('foo')->category);
+        $this->assertEquals('bar', DocumentationSidebarService::get()->first()->category);
+    }
+
     protected function resetDocsDirectory(): void
     {
         File::deleteDirectory(Hyde::path('_docs'));


### PR DESCRIPTION
Introducing a new extension that allows you to group together pages in the documentation page sidebar. The feature is enabled automatically when at least one documentation page has a `category` set in the front matter.

---
category: "Getting Started"
---

![image](https://user-images.githubusercontent.com/95144705/167874253-1e40b50f-ede5-41bd-88da-178fd71d4332.png)

Pages that don't have a category defined gets put in the `other` category, but only if there are any categories defined.

Draft until:

- [ ] HydeFront is ready for merge
- [ ] Implement ordering sidebar items (based on the lowest item priority in each category, (`other` category has priority 999))