### PR TITLE
Change BuildService to DiscoveryService

### DIFF
--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -12,7 +12,7 @@ use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
-use Hyde\Framework\Services\BuildService;
+use Hyde\Framework\Services\DiscoveryService;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use LaravelZero\Framework\Commands\Command;
@@ -112,7 +112,7 @@ class HydeBuildStaticSiteCommand extends Command
         $this->info('Congratulations! 🎉 Your static site has been built!');
         $this->line(
             'Your new homepage is stored here -> '.
-                BuildService::createClickableFilepath(Hyde::path('_site/index.html'))
+                DiscoveryService::createClickableFilepath(Hyde::path('_site/index.html'))
         );
     }
 

--- a/src/Commands/HydeRebuildStaticSiteCommand.php
+++ b/src/Commands/HydeRebuildStaticSiteCommand.php
@@ -5,7 +5,7 @@ namespace Hyde\Framework\Commands;
 use Exception;
 use Hyde\Framework\Concerns\Internal\TransfersMediaAssetsForBuildCommands;
 use Hyde\Framework\Hyde;
-use Hyde\Framework\Services\BuildService;
+use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Framework\Services\RebuildService;
 use LaravelZero\Framework\Commands\Command;
 
@@ -68,7 +68,7 @@ class HydeRebuildStaticSiteCommand extends Command
 
         $this->info(sprintf(
             'Created %s in %s seconds. (%sms)',
-            BuildService::createClickableFilepath($this->getOutputPath($this->path)),
+            DiscoveryService::createClickableFilepath($this->getOutputPath($this->path)),
             number_format(
                 $execution_time,
                 2

--- a/src/Concerns/Internal/BuildActionRunner.php
+++ b/src/Concerns/Internal/BuildActionRunner.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Concerns\Internal;
 
-use Hyde\Framework\Services\BuildService;
+use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Framework\Services\CollectionService;
 use Hyde\Framework\StaticPageBuilder;
 
@@ -40,7 +40,7 @@ trait BuildActionRunner
                 $collection,
                 function ($basename) use ($model) {
                     new StaticPageBuilder(
-                        BuildService::getParserInstanceForModel(
+                        DiscoveryService::getParserInstanceForModel(
                             $model,
                             $basename
                         )->get(),

--- a/src/Services/DiscoveryService.php
+++ b/src/Services/DiscoveryService.php
@@ -55,7 +55,7 @@ class DiscoveryService
      *
      * @param string $filepath
      * @return string|false The model class constant, or false if none was found.
-     * @see \Tests\Unit\BuildServiceCanFindModelFromCustomSourceFilePathTest
+     * @see \Tests\Unit\DiscoveryServiceCanFindModelFromCustomSourceFilePathTest
      *
      */
     public static function findModelFromFilePath(string $filepath): string|false

--- a/src/Services/DiscoveryService.php
+++ b/src/Services/DiscoveryService.php
@@ -8,11 +8,11 @@ use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
 
 /**
- * Static service helpers for building static pages.
- *
- * @deprecated may be renamed to DiscoveryService
+ * The Discovery Service (previously called BuildService) provides
+ * helper methods for source file autodiscovery used in the building
+ * process to determine where files are located and how to parse them.
  */
-class BuildService
+class DiscoveryService
 {
     public static function getParserClassForModel(string $model): string
     {

--- a/src/Services/DiscoveryService.php
+++ b/src/Services/DiscoveryService.php
@@ -53,9 +53,10 @@ class DiscoveryService
     /**
      * Determine the Page Model to use for a given file path.
      *
+     * @param string $filepath
+     * @return string|false The model class constant, or false if none was found.
      * @see \Tests\Unit\BuildServiceCanFindModelFromCustomSourceFilePathTest
      *
-     * @return string The model class constant, or false if none was found.
      */
     public static function findModelFromFilePath(string $filepath): string|false
     {

--- a/src/Services/RebuildService.php
+++ b/src/Services/RebuildService.php
@@ -44,7 +44,7 @@ class RebuildService
     public function __construct(string $filepath)
     {
         $this->filepath = $filepath;
-        $this->model = BuildService::findModelFromFilePath($this->filepath);
+        $this->model = DiscoveryService::findModelFromFilePath($this->filepath);
     }
 
     /**
@@ -53,15 +53,15 @@ class RebuildService
     public function execute(): StaticPageBuilder
     {
         return $this->builder = (new StaticPageBuilder(
-            BuildService::getParserInstanceForModel(
+            DiscoveryService::getParserInstanceForModel(
                 $this->model,
                 basename(
                     str_replace(
-                        BuildService::getFilePathForModelClassFiles($this->model).'/',
+                        DiscoveryService::getFilePathForModelClassFiles($this->model).'/',
                         '',
                         $this->filepath
                     ),
-                    BuildService::getFileExtensionForModelFiles($this->model)
+                    DiscoveryService::getFileExtensionForModelFiles($this->model)
                 )
             )->get(),
             true

--- a/tests/Feature/BuildServiceTest.php
+++ b/tests/Feature/BuildServiceTest.php
@@ -10,78 +10,78 @@ use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
-use Hyde\Framework\Services\BuildService;
+use Hyde\Framework\Services\DiscoveryService;
 use Tests\TestCase;
 
 class BuildServiceTest extends TestCase
 {
     public function createContentSourceTestFiles()
     {
-        touch(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPost::class).'/test.md'));
-        touch(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPage::class).'/test.md'));
-        touch(Hyde::path(BuildService::getFilePathForModelClassFiles(DocumentationPage::class).'/test.md'));
-        touch(Hyde::path(BuildService::getFilePathForModelClassFiles(BladePage::class).'/test.blade.php'));
+        touch(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(MarkdownPost::class).'/test.md'));
+        touch(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(MarkdownPage::class).'/test.md'));
+        touch(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(DocumentationPage::class).'/test.md'));
+        touch(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(BladePage::class).'/test.blade.php'));
     }
 
     public function deleteContentSourceTestFiles()
     {
-        unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPost::class).'/test.md'));
-        unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(MarkdownPage::class).'/test.md'));
-        unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(DocumentationPage::class).'/test.md'));
-        unlink(Hyde::path(BuildService::getFilePathForModelClassFiles(BladePage::class).'/test.blade.php'));
+        unlink(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(MarkdownPost::class).'/test.md'));
+        unlink(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(MarkdownPage::class).'/test.md'));
+        unlink(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(DocumentationPage::class).'/test.md'));
+        unlink(Hyde::path(DiscoveryService::getFilePathForModelClassFiles(BladePage::class).'/test.blade.php'));
     }
 
     public function test_find_model_from_file_path()
     {
-        $this->assertEquals(MarkdownPage::class, BuildService::findModelFromFilePath('_pages/test.md'));
-        $this->assertEquals(MarkdownPost::class, BuildService::findModelFromFilePath('_posts/test.md'));
-        $this->assertEquals(DocumentationPage::class, BuildService::findModelFromFilePath('_docs/test.md'));
-        $this->assertEquals(BladePage::class, BuildService::findModelFromFilePath('_pages/test.blade.php'));
+        $this->assertEquals(MarkdownPage::class, DiscoveryService::findModelFromFilePath('_pages/test.md'));
+        $this->assertEquals(MarkdownPost::class, DiscoveryService::findModelFromFilePath('_posts/test.md'));
+        $this->assertEquals(DocumentationPage::class, DiscoveryService::findModelFromFilePath('_docs/test.md'));
+        $this->assertEquals(BladePage::class, DiscoveryService::findModelFromFilePath('_pages/test.blade.php'));
 
-        $this->assertFalse(BuildService::findModelFromFilePath('_foo/test.txt'));
+        $this->assertFalse(DiscoveryService::findModelFromFilePath('_foo/test.txt'));
     }
 
     public function test_get_parser_class_for_model()
     {
-        $this->assertEquals(MarkdownPageParser::class, BuildService::getParserClassForModel(MarkdownPage::class));
-        $this->assertEquals(MarkdownPostParser::class, BuildService::getParserClassForModel(MarkdownPost::class));
-        $this->assertEquals(DocumentationPageParser::class, BuildService::getParserClassForModel(DocumentationPage::class));
-        $this->assertEquals(BladePage::class, BuildService::getParserClassForModel(BladePage::class));
+        $this->assertEquals(MarkdownPageParser::class, DiscoveryService::getParserClassForModel(MarkdownPage::class));
+        $this->assertEquals(MarkdownPostParser::class, DiscoveryService::getParserClassForModel(MarkdownPost::class));
+        $this->assertEquals(DocumentationPageParser::class, DiscoveryService::getParserClassForModel(DocumentationPage::class));
+        $this->assertEquals(BladePage::class, DiscoveryService::getParserClassForModel(BladePage::class));
     }
 
     public function test_get_parser_instance_for_model()
     {
         $this->createContentSourceTestFiles();
 
-        $this->assertInstanceOf(MarkdownPageParser::class, BuildService::getParserInstanceForModel(MarkdownPage::class, 'test'));
-        $this->assertInstanceOf(MarkdownPostParser::class, BuildService::getParserInstanceForModel(MarkdownPost::class, 'test'));
-        $this->assertInstanceOf(DocumentationPageParser::class, BuildService::getParserInstanceForModel(DocumentationPage::class, 'test'));
-        $this->assertInstanceOf(BladePage::class, BuildService::getParserInstanceForModel(BladePage::class, 'test'));
+        $this->assertInstanceOf(MarkdownPageParser::class, DiscoveryService::getParserInstanceForModel(MarkdownPage::class, 'test'));
+        $this->assertInstanceOf(MarkdownPostParser::class, DiscoveryService::getParserInstanceForModel(MarkdownPost::class, 'test'));
+        $this->assertInstanceOf(DocumentationPageParser::class, DiscoveryService::getParserInstanceForModel(DocumentationPage::class, 'test'));
+        $this->assertInstanceOf(BladePage::class, DiscoveryService::getParserInstanceForModel(BladePage::class, 'test'));
 
         $this->deleteContentSourceTestFiles();
     }
 
     public function test_get_file_extension_for_model_files()
     {
-        $this->assertEquals('.md', BuildService::getFileExtensionForModelFiles(MarkdownPage::class));
-        $this->assertEquals('.md', BuildService::getFileExtensionForModelFiles(MarkdownPost::class));
-        $this->assertEquals('.md', BuildService::getFileExtensionForModelFiles(DocumentationPage::class));
-        $this->assertEquals('.blade.php', BuildService::getFileExtensionForModelFiles(BladePage::class));
+        $this->assertEquals('.md', DiscoveryService::getFileExtensionForModelFiles(MarkdownPage::class));
+        $this->assertEquals('.md', DiscoveryService::getFileExtensionForModelFiles(MarkdownPost::class));
+        $this->assertEquals('.md', DiscoveryService::getFileExtensionForModelFiles(DocumentationPage::class));
+        $this->assertEquals('.blade.php', DiscoveryService::getFileExtensionForModelFiles(BladePage::class));
     }
 
     public function test_get_file_path_for_model_class_files()
     {
-        $this->assertEquals('_posts', BuildService::getFilePathForModelClassFiles(MarkdownPost::class));
-        $this->assertEquals('_pages', BuildService::getFilePathForModelClassFiles(MarkdownPage::class));
-        $this->assertEquals('_docs', BuildService::getFilePathForModelClassFiles(DocumentationPage::class));
-        $this->assertEquals('_pages', BuildService::getFilePathForModelClassFiles(BladePage::class));
+        $this->assertEquals('_posts', DiscoveryService::getFilePathForModelClassFiles(MarkdownPost::class));
+        $this->assertEquals('_pages', DiscoveryService::getFilePathForModelClassFiles(MarkdownPage::class));
+        $this->assertEquals('_docs', DiscoveryService::getFilePathForModelClassFiles(DocumentationPage::class));
+        $this->assertEquals('_pages', DiscoveryService::getFilePathForModelClassFiles(BladePage::class));
     }
 
     public function test_create_clickable_filepath()
     {
         $filename = 'be2329d7-3596-48f4-b5b8-deff352246a9';
         touch($filename);
-        $output = BuildService::createClickableFilepath($filename);
+        $output = DiscoveryService::createClickableFilepath($filename);
         $this->assertStringContainsString('file://', $output);
         $this->assertStringContainsString($filename, $output);
         unlink($filename);

--- a/tests/Feature/DiscoveryServiceTest.php
+++ b/tests/Feature/DiscoveryServiceTest.php
@@ -13,7 +13,7 @@ use Hyde\Framework\Models\MarkdownPost;
 use Hyde\Framework\Services\DiscoveryService;
 use Tests\TestCase;
 
-class BuildServiceTest extends TestCase
+class DiscoveryServiceTest extends TestCase
 {
     public function createContentSourceTestFiles()
     {

--- a/tests/Feature/SourceDirectoriesCanBeChangedTest.php
+++ b/tests/Feature/SourceDirectoriesCanBeChangedTest.php
@@ -7,7 +7,7 @@ use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
-use Hyde\Framework\Services\BuildService;
+use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Framework\Services\CollectionService;
 use Tests\TestCase;
 
@@ -43,7 +43,7 @@ class SourceDirectoriesCanBeChangedTest extends TestCase
 
         $this->assertEquals(
             '_source/posts',
-            BuildService::getFilePathForModelClassFiles(MarkdownPost::class)
+            DiscoveryService::getFilePathForModelClassFiles(MarkdownPost::class)
         );
     }
 

--- a/tests/Unit/BuildServiceCanFindModelFromCustomSourceFilePathTest.php
+++ b/tests/Unit/BuildServiceCanFindModelFromCustomSourceFilePathTest.php
@@ -6,14 +6,14 @@ use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
-use Hyde\Framework\Services\BuildService;
+use Hyde\Framework\Services\DiscoveryService;
 use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
 
 /**
  * Class BuildServiceCanFindModelFromCustomSourceFilePathTest.
  *
- * @covers \Hyde\Framework\BuildService::findModelFromFilePath()
+ * @covers \Hyde\Framework\DiscoveryService::findModelFromFilePath()
  */
 class BuildServiceCanFindModelFromCustomSourceFilePathTest extends TestCase
 {
@@ -32,7 +32,7 @@ class BuildServiceCanFindModelFromCustomSourceFilePathTest extends TestCase
     {
         $this->assertEquals(
             BladePage::class,
-            BuildService::findModelFromFilePath('.source/pages/test.blade.php')
+            DiscoveryService::findModelFromFilePath('.source/pages/test.blade.php')
         );
     }
 
@@ -40,7 +40,7 @@ class BuildServiceCanFindModelFromCustomSourceFilePathTest extends TestCase
     {
         $this->assertEquals(
             MarkdownPage::class,
-            BuildService::findModelFromFilePath('.source/pages/test.md')
+            DiscoveryService::findModelFromFilePath('.source/pages/test.md')
         );
     }
 
@@ -48,7 +48,7 @@ class BuildServiceCanFindModelFromCustomSourceFilePathTest extends TestCase
     {
         $this->assertEquals(
             MarkdownPost::class,
-            BuildService::findModelFromFilePath('.source/posts/test.md')
+            DiscoveryService::findModelFromFilePath('.source/posts/test.md')
         );
     }
 
@@ -56,7 +56,7 @@ class BuildServiceCanFindModelFromCustomSourceFilePathTest extends TestCase
     {
         $this->assertEquals(
             DocumentationPage::class,
-            BuildService::findModelFromFilePath('.source/docs/test.md')
+            DiscoveryService::findModelFromFilePath('.source/docs/test.md')
         );
     }
 }

--- a/tests/Unit/DiscoveryServiceCanFindModelFromCustomSourceFilePathTest.php
+++ b/tests/Unit/DiscoveryServiceCanFindModelFromCustomSourceFilePathTest.php
@@ -11,11 +11,11 @@ use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
 
 /**
- * Class BuildServiceCanFindModelFromCustomSourceFilePathTest.
+ * Class DiscoveryServiceCanFindModelFromCustomSourceFilePathTest.
  *
  * @covers \Hyde\Framework\DiscoveryService::findModelFromFilePath()
  */
-class BuildServiceCanFindModelFromCustomSourceFilePathTest extends TestCase
+class DiscoveryServiceCanFindModelFromCustomSourceFilePathTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/tests/Unit/SourceFilesInCustomDirectoriesCanBeCompiledTest.php
+++ b/tests/Unit/SourceFilesInCustomDirectoriesCanBeCompiledTest.php
@@ -7,7 +7,7 @@ use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
-use Hyde\Framework\Services\BuildService;
+use Hyde\Framework\Services\DiscoveryService;
 use Hyde\Framework\StaticPageBuilder;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
@@ -41,7 +41,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
 
         // Uses the same logic as the BuildActionRunner for an accurate test.
         new StaticPageBuilder(
-            BuildService::getParserInstanceForModel(
+            DiscoveryService::getParserInstanceForModel(
                 MarkdownPost::class,
                 'test'
             )->get(),
@@ -61,7 +61,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
 
         // Uses the same logic as the BuildActionRunner for an accurate test.
         new StaticPageBuilder(
-            BuildService::getParserInstanceForModel(
+            DiscoveryService::getParserInstanceForModel(
                 MarkdownPage::class,
                 'test'
             )->get(),
@@ -81,7 +81,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
 
         // Uses the same logic as the BuildActionRunner for an accurate test.
         new StaticPageBuilder(
-            BuildService::getParserInstanceForModel(
+            DiscoveryService::getParserInstanceForModel(
                 DocumentationPage::class,
                 'test'
             )->get(),
@@ -102,7 +102,7 @@ class SourceFilesInCustomDirectoriesCanBeCompiledTest extends TestCase
 
         // Uses the same logic as the BuildActionRunner for an accurate test.
         new StaticPageBuilder(
-            BuildService::getParserInstanceForModel(
+            DiscoveryService::getParserInstanceForModel(
                 BladePage::class,
                 'test'
             )->get(),


### PR DESCRIPTION
Since the BuildService mainly contains helpers regarding file discovery, this PR renames it to DiscoveryService. And since I think it satisfies all requirements in the related issue, I think this will close https://github.com/hydephp/framework/issues/336.