### PR TITLE
Add sidebar config offset, fix #307

### DIFF
--- a/src/Models/DocumentationSidebarItem.php
+++ b/src/Models/DocumentationSidebarItem.php
@@ -36,7 +36,11 @@ class DocumentationSidebarItem
             return 500;
         }
 
-        return array_search($slug, $orderIndexArray); //  + 250?
+        return array_search($slug, $orderIndexArray) + 250;
+
+        // Adding 250 makes so that pages with a front matter priority that is lower
+        // can be shown first. It's lower than the fallback of 500 so that they
+        // still come first. This is all to make it easier to mix priorities.
     }
 
     public function isHidden(): bool

--- a/tests/Feature/Services/DocumentationSidebarServiceTest.php
+++ b/tests/Feature/Services/DocumentationSidebarServiceTest.php
@@ -132,7 +132,7 @@ class DocumentationSidebarServiceTest extends TestCase
         $this->assertEquals(25, DocumentationSidebarService::get()->first()->priority);
     }
 
-    public function test_both_sidebar_priority_setting_methods_can_be_used()
+    public function test_sidebar_priorities_can_be_set_in_both_front_matter_and_config()
     {
         Config::set('hyde.documentationPageOrder', [
             'first',
@@ -142,7 +142,7 @@ class DocumentationSidebarServiceTest extends TestCase
         touch(Hyde::path('_docs/first.md'));
         touch(Hyde::path('_docs/second.md'));
         file_put_contents(Hyde::path('_docs/third.md'),
-            (new ConvertsArrayToFrontMatter)->execute(['priority' => 3])
+            (new ConvertsArrayToFrontMatter)->execute(['priority' => 300])
         );
         $sidebar = DocumentationSidebarService::get();
         $this->assertEquals('first', $sidebar[0]->destination);


### PR DESCRIPTION
Makes so that the default priority value for documentation sidebar pages is 500. When an item is present in config, they get priority 250 + their order in the array, thus still putting them before pages without a defined priority, while allowing front matter to override and be put before config orderings.