### PR TITLE
Add configurable "pretty URLs"

### DIFF
--- a/resources/views/components/article-excerpt.blade.php
+++ b/resources/views/components/article-excerpt.blade.php
@@ -9,7 +9,7 @@
 @endif
     
 	<header>
-		<a href="posts/{{ $post->slug }}.html" class="block w-fit">
+		<a href="posts/{{ Hyde::pageLink($post->slug . '.html') }}" class="block w-fit">
 			<h2 class="text-2xl font-bold text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white transition-colors duration-75">
 				{{ $post->matter['title'] ?? $post->title }}
 			</h2>
@@ -42,6 +42,6 @@
 @endisset
 
 	<footer>
-		<a href="posts/{{ $post->slug }}.html" class="text-indigo-500 hover:underline font-medium">Read post</a>
+		<a href="posts/{{ Hyde::pageLink($post->slug . '.html') }}" class="text-indigo-500 hover:underline font-medium">Read post</a>
 	</footer>
 </article>

--- a/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
+++ b/resources/views/components/docs/labeled-sidebar-navigation-menu.blade.php
@@ -6,13 +6,13 @@
 			@foreach ($sidebar->getItemsInCategory($category) as $item)
 			<li @class([ 'sidebar-navigation-item' , 'active'=> $item->destination === basename($currentPage)]) role="listitem">
 				@if($item->destination === basename($currentPage))
-				<a href="{{ $item->destination }}.html" aria-current="true">{{ $item->label }}</a>
+				<a href="{{ Hyde::pageLink($item->destination . '.html') }}" aria-current="true">{{ $item->label }}</a>
 				@if(isset($docs->tableOfContents))
 				<span class="sr-only">Table of contents</span>
 				{!! ($docs->tableOfContents) !!}
 				@endif
 				@else
-				<a href="{{ $item->destination }}.html">{{ $item->label }}</a>
+				<a href="{{ Hyde::pageLink($item->destination . '.html') }}">{{ $item->label }}</a>
 				@endif
 			</li role="listitem">
 			@endforeach

--- a/resources/views/components/docs/sidebar-navigation-menu.blade.php
+++ b/resources/views/components/docs/sidebar-navigation-menu.blade.php
@@ -2,7 +2,7 @@
 	@foreach ($sidebar->getSidebar() as $item)
 	<li @class([ 'sidebar-navigation-item' , 'active'=> $item->destination === basename($currentPage)])>
 		@if($item->destination === basename($currentPage))
-		<a href="{{ $item->destination }}.html" aria-current="true">{{
+		<a href="{{ Hyde::pageLink($item->destination . '.html') }}" aria-current="true">{{
 			$item->label }}</a>
 
 		@if(isset($docs->tableOfContents))
@@ -10,7 +10,7 @@
 		{!! ($docs->tableOfContents) !!}
 		@endif
 		@else
-		<a href="{{ $item->destination }}.html">{{ $item->label }}</a>
+		<a href="{{ Hyde::pageLink($item->destination . '.html') }}">{{ $item->label }}</a>
 		@endif
 	</li>
 	@endforeach

--- a/resources/views/homepages/welcome.blade.php
+++ b/resources/views/homepages/welcome.blade.php
@@ -65,7 +65,7 @@
                                 </a>
                             </li>
                             <li>
-                                <a href="https://hydephp.github.io/docs/master/getting-started.html" class="uppercase font-bold text-sm flex text-center m-2 mx-3">
+                                <a href="https://hydephp.github.io/docs/master/getting-started" class="uppercase font-bold text-sm flex text-center m-2 mx-3">
                                     Getting Started
                                 </a>
                             </li>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -57,7 +57,7 @@
 		</nav>
 		<footer id="sidebar-footer">
 			<p>
-				<a href="{{ Hyde::relativePath('index.html', $currentPage) }}">Back to home page</a>
+				<a href="{{ Hyde::relativeLink('index.html', $currentPage) }}">Back to home page</a>
 			</p>
 		</footer>
 	</aside>

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -14,7 +14,7 @@
 	<nav id="mobile-navigation">
 		<strong class="mr-auto">
 			@if(Hyde::docsIndexPath() !== false)
-			<a href="{{ basename(Hyde::docsIndexPath()) }}">
+			<a href="{{ Hyde::relativeLink(Hyde::docsIndexPath(), $currentPage) }}">
 				{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
 			</a>
 			@else
@@ -34,7 +34,7 @@
 			<div id="sidebar-brand">
 				<strong>
 					@if(Hyde::docsIndexPath() !== false)
-					<a href="{{ basename(Hyde::docsIndexPath()) }}">
+					<a href="{{ Hyde::relativeLink(Hyde::docsIndexPath(), $currentPage) }}">
 						{{ config('hyde.docsSidebarHeaderTitle', 'Documentation') }}
 					</a>
 					@else

--- a/resources/views/layouts/head.blade.php
+++ b/resources/views/layouts/head.blade.php
@@ -3,7 +3,7 @@
 <title>{{ isset($title) ? config('hyde.name', 'HydePHP') . ' - ' . $title : config('hyde.name', 'HydePHP') }}</title>
 
 @if (file_exists(Hyde::path('_media/favicon.ico'))) 
-<link rel="shortcut icon" href="{{ Hyde::relativePath('media/favicon.ico', $currentPage) }}" type="image/x-icon">
+<link rel="shortcut icon" href="{{ Hyde::relativeLink('media/favicon.ico', $currentPage) }}" type="image/x-icon">
 @endif
 
 {{-- App Meta Tags --}}

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,6 +1,6 @@
 @php
 $links = Hyde\Framework\Actions\GeneratesNavigationMenu::getNavigationLinks($currentPage);
-$homeRoute = ($links[array_search('Home', array_column($links, 'title'))])['route'] ?? 'index.html';
+$homeRoute = ($links[array_search('Home', array_column($links, 'title'))])['route'] ?? Hyde::pageLink('index.html');
 @endphp
 
 <nav aria-label="Main navigation" id="main-navigation" class="flex flex-wrap items-center justify-between p-4 shadow-lg sm:shadow-xl md:shadow-none dark:bg-gray-800">

--- a/src/Actions/GeneratesNavigationMenu.php
+++ b/src/Actions/GeneratesNavigationMenu.php
@@ -10,6 +10,7 @@ use JetBrains\PhpStorm\Pure;
 
 /**
  * Generate the dynamic navigation menu.
+ * @todo #350 Replace hard-coded source paths with page model properties
  */
 class GeneratesNavigationMenu
 {

--- a/src/Actions/GeneratesNavigationMenu.php
+++ b/src/Actions/GeneratesNavigationMenu.php
@@ -177,14 +177,7 @@ class GeneratesNavigationMenu
      */
     private function getRelativeRoutePathForSlug(string $slug): string
     {
-        $nestCount = substr_count($this->currentPage, '/');
-        $route = '';
-        if ($nestCount > 0) {
-            $route .= str_repeat('../', $nestCount);
-        }
-        $route .= $slug.'.html';
-
-        return $route;
+        return Hyde::relativeLink($slug.'.html', $this->currentPage);
     }
 
     /**

--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -36,6 +36,7 @@ class HydeBuildStaticSiteCommand extends Command
         {--run-dev : Run the NPM dev script after build}
         {--run-prod : Run the NPM prod script after build}
         {--pretty : Should the build files be prettified?}
+        {--pretty-urls : Should links in output use pretty URLs?}
         {--no-api : Disable external API calls, such as Torchlight}';
 
     /**
@@ -96,6 +97,12 @@ class HydeBuildStaticSiteCommand extends Command
             $config = config('hyde.features');
             unset($config[array_search('torchlight', $config)]);
             Config::set(['hyde.features' => $config]);
+        }
+
+        if ($this->option('pretty-urls')) {
+            $this->info('Generating site with pretty URLs');
+            $this->newLine();
+            Config::set(['hyde.prettyUrls' => true]);
         }
     }
 

--- a/src/Concerns/Internal/FileHelpers.php
+++ b/src/Concerns/Internal/FileHelpers.php
@@ -4,6 +4,9 @@ namespace Hyde\Framework\Concerns\Internal;
 
 /**
  * Offloads file helper methods for the Hyde Facade.
+ * 
+ * If a method uses the name `path` it refers to an internal file path.
+ * if a method uses the name `link` it refers to a web link used in Blade templates.
  *
  * @see \Hyde\Framework\Hyde
  */

--- a/src/Concerns/Internal/FileHelpers.php
+++ b/src/Concerns/Internal/FileHelpers.php
@@ -74,6 +74,21 @@ trait FileHelpers
     }
 
     /**
+     * Format a link to an HTML file, allowing for pretty URLs, if enabled.
+     * @see \Tests\Unit\HydeFileHelperForPageLinksCanCreatePrettyUrlsTest
+     */
+    public static function pageLink(string $destination): string
+    {
+        if (config('hyde.prettyUrls', false) === true) {
+            if (str_ends_with($destination, '.html')) {
+                return substr($destination, 0, -5);
+            }
+        }
+
+        return $destination;
+    }
+
+    /**
      * Inject the proper number of `../` before the links in Blade templates.
      *
      * @param  string  $destination  the route to format

--- a/src/Concerns/Internal/FileHelpers.php
+++ b/src/Concerns/Internal/FileHelpers.php
@@ -90,9 +90,10 @@ trait FileHelpers
 
     /**
      * Inject the proper number of `../` before the links in Blade templates.
+     * @see \Tests\Unit\FileHelperRelativeLinkTest
      *
-     * @param  string  $destination  the route to format
-     * @param  string  $current  the current route
+     * @param  string  $destination  relative to `_site` directory on compiled site
+     * @param  string  $current  the current URI path relative to the same root
      * @return string
      */
     public static function relativeLink(string $destination, string $current = ''): string

--- a/src/Concerns/Internal/FileHelpers.php
+++ b/src/Concerns/Internal/FileHelpers.php
@@ -85,6 +85,9 @@ trait FileHelpers
                 if ($destination === 'index.html') {
                     return '/';
                 }
+                if ($destination === static::docsDirectory().'/index.html') {
+                    return static::docsDirectory().'/';
+                }
 
                 return substr($destination, 0, -5);
             }

--- a/src/Concerns/Internal/FileHelpers.php
+++ b/src/Concerns/Internal/FileHelpers.php
@@ -75,7 +75,7 @@ trait FileHelpers
 
     /**
      * Format a link to an HTML file, allowing for pretty URLs, if enabled.
-     * @see \Tests\Unit\HydeFileHelperForPageLinksCanCreatePrettyUrlsTest
+     * @see \Tests\Unit\FileHelperPageLinkPrettyUrlTest
      */
     public static function pageLink(string $destination): string
     {

--- a/src/Concerns/Internal/FileHelpers.php
+++ b/src/Concerns/Internal/FileHelpers.php
@@ -81,6 +81,9 @@ trait FileHelpers
     {
         if (config('hyde.prettyUrls', false) === true) {
             if (str_ends_with($destination, '.html')) {
+                if ($destination === 'index.html') {
+                    return '/';
+                }
                 return substr($destination, 0, -5);
             }
         }
@@ -105,7 +108,7 @@ trait FileHelpers
         }
         $route .= static::pageLink($destination);
 
-        return $route;
+        return str_replace('//', '/', $route);
     }
 
     /**

--- a/src/Concerns/Internal/FileHelpers.php
+++ b/src/Concerns/Internal/FileHelpers.php
@@ -103,7 +103,7 @@ trait FileHelpers
         if ($nestCount > 0) {
             $route .= str_repeat('../', $nestCount);
         }
-        $route .= $destination;
+        $route .= static::pageLink($destination);
 
         return $route;
     }

--- a/src/Concerns/Internal/FileHelpers.php
+++ b/src/Concerns/Internal/FileHelpers.php
@@ -71,14 +71,6 @@ trait FileHelpers
     }
 
     /**
-     * @deprecated use relativeLink() instead
-     */
-    public static function relativePath(string $destination, string $current = ''): string
-    {
-        return static::relativeLink($destination, $current);
-    }
-
-    /**
      * Inject the proper number of `../` before the links in Blade templates.
      *
      * @param  string  $destination  the route to format

--- a/src/Concerns/Internal/FileHelpers.php
+++ b/src/Concerns/Internal/FileHelpers.php
@@ -30,11 +30,11 @@ trait FileHelpers
     public static function docsIndexPath(): string|false
     {
         if (file_exists(static::path('_docs/index.md'))) {
-            return static::docsDirectory().'/index.html';
+            return static::pageLink(static::docsDirectory().'/index.html');
         }
 
         if (file_exists(static::path('_docs/readme.md'))) {
-            return static::docsDirectory().'/readme.html';
+            return static::pageLink(static::docsDirectory().'/readme.html');
         }
 
         return false;

--- a/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
+++ b/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
@@ -80,4 +80,16 @@ class FileHelperPageLinkPrettyUrlTest extends TestCase
         config(['hyde.prettyUrls' => false]);
         $this->assertEquals('index.html', Hyde::pageLink('index.html'));
     }
+
+    public function test_helper_rewrites_documentation_page_index_when_using_pretty_urls()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('docs/', Hyde::pageLink('docs/index.html'));
+    }
+
+    public function test_helper_does_not_rewrite_documentation_page_index_when_not_using_pretty_urls()
+    {
+        config(['hyde.prettyUrls' => false]);
+        $this->assertEquals('docs/index.html', Hyde::pageLink('docs/index.html'));
+    }
 }

--- a/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
+++ b/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
@@ -74,4 +74,10 @@ class FileHelperPageLinkPrettyUrlTest extends TestCase
         config(['hyde.prettyUrls' => true]);
         $this->assertEquals('/', Hyde::pageLink('index.html'));
     }
+
+    public function test_helper_does_not_rewrite_index_when_not_using_pretty_urls()
+    {
+        config(['hyde.prettyUrls' => false]);
+        $this->assertEquals('index.html', Hyde::pageLink('index.html'));
+    }	
 }

--- a/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
+++ b/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
@@ -68,4 +68,10 @@ class FileHelperPageLinkPrettyUrlTest extends TestCase
         config(['hyde.prettyUrls' => true]);
         $this->assertEquals('/foo/bar.jpg', Hyde::pageLink('/foo/bar.jpg'));
     }
+
+    public function test_helper_rewrites_index_when_using_pretty_urls()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('/', Hyde::pageLink('index.html'));
+    }
 }

--- a/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
+++ b/tests/Unit/FileHelperPageLinkPrettyUrlTest.php
@@ -6,11 +6,11 @@ use Hyde\Framework\Hyde;
 use Tests\TestCase;
 
 /**
- * Class HydeFileHelperForPageLinksCanCreatePrettyUrlsTest.
+ * Class FileHelperPageLinkPrettyUrlTest.
  *
  * @covers \Hyde\Framework\Concerns\Internal\FileHelpers
  */
-class HydeFileHelperForPageLinksCanCreatePrettyUrlsTest extends TestCase
+class FileHelperPageLinkPrettyUrlTest extends TestCase
 {
     public function test_helper_returns_string_as_is_if_pretty_urls_is_not_true()
     {

--- a/tests/Unit/FileHelperRelativeLinkTest.php
+++ b/tests/Unit/FileHelperRelativeLinkTest.php
@@ -83,4 +83,12 @@ class FileHelperRelativeLinkTest extends TestCase
         config(['hyde.prettyUrls' => true]);
         $this->assertEquals('../foo.png', Hyde::relativeLink('foo.png', 'foo/bar.html'));
     }
+
+    public function test_helper_rewrites_index_when_using_pretty_urls()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('/', Hyde::relativeLink('index.html', 'foo.html'));
+        $this->assertEquals('../', Hyde::relativeLink('index.html', 'foo/bar.html'));
+        $this->assertEquals('../../', Hyde::relativeLink('index.html', 'foo/bar/baz.html'));
+    }
 }

--- a/tests/Unit/FileHelperRelativeLinkTest.php
+++ b/tests/Unit/FileHelperRelativeLinkTest.php
@@ -99,4 +99,13 @@ class FileHelperRelativeLinkTest extends TestCase
         $this->assertEquals('../index.html', Hyde::relativeLink('index.html', 'foo/bar.html'));
         $this->assertEquals('../../index.html', Hyde::relativeLink('index.html', 'foo/bar/baz.html'));
     }
+
+    public function test_helper_rewrites_documentation_page_index_when_using_pretty_urls()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('docs/', Hyde::relativeLink('docs/index.html', 'foo.html'));
+        $this->assertEquals('docs/', Hyde::relativeLink('docs/index.html', 'docs.html'));
+        $this->assertEquals('../docs/', Hyde::relativeLink('docs/index.html', 'foo/bar.html'));
+        $this->assertEquals('../docs/', Hyde::relativeLink('docs/index.html', 'docs/foo.html'));
+    }
 }

--- a/tests/Unit/FileHelperRelativeLinkTest.php
+++ b/tests/Unit/FileHelperRelativeLinkTest.php
@@ -21,38 +21,38 @@ class FileHelperRelativeLinkTest extends TestCase
     // Test helper injects the proper number of `../` 
     public function test_helper_injects_proper_number_of_doubles_slash()
     {
-        $this->assertEquals('../index.html', Hyde::relativeLink('index.html', 'foo/bar.html'));
+        $this->assertEquals('../foo.html', Hyde::relativeLink('foo.html', 'foo/bar.html'));
     }
 
     // Test helper injects the proper number of `../` for deeply nested $current paths
     public function test_helper_injects_proper_number_of_doubles_slash_for_deeply_nested_paths()
     {
-        $this->assertEquals('../../../index.html', Hyde::relativeLink('index.html', 'foo/bar/baz/qux.html'));
+        $this->assertEquals('../../../foo.html', Hyde::relativeLink('foo.html', 'foo/bar/baz/qux.html'));
     }
 
     // Test helper handles destination without file extension
     public function test_helper_handles_destination_without_file_extension()
     {
-        $this->assertEquals('../index', Hyde::relativeLink('index', 'foo/bar.html'));
+        $this->assertEquals('../foo', Hyde::relativeLink('foo', 'foo/bar.html'));
     }
 
     // Test helper handles $current without file extension
     public function test_helper_handles_current_without_file_extension()
     {
-        $this->assertEquals('../index.html', Hyde::relativeLink('index.html', 'foo/bar'));
+        $this->assertEquals('../foo.html', Hyde::relativeLink('foo.html', 'foo/bar'));
     }
 
     // Test helper handles case without any file extensions
     public function test_helper_handles_case_without_any_file_extensions()
     {
-        $this->assertEquals('../index', Hyde::relativeLink('index', 'foo/bar'));
+        $this->assertEquals('../foo', Hyde::relativeLink('foo', 'foo/bar'));
     }
 
     // Test helper handles case with mixed file extensions
     public function test_helper_handles_case_with_mixed_file_extensions()
     {
-        $this->assertEquals('../index.md', Hyde::relativeLink('index.md', 'foo/bar.md'));
-        $this->assertEquals('../index.txt', Hyde::relativeLink('index.txt', 'foo/bar.txt'));
+        $this->assertEquals('../foo.md', Hyde::relativeLink('foo.md', 'foo/bar.md'));
+        $this->assertEquals('../foo.txt', Hyde::relativeLink('foo.txt', 'foo/bar.txt'));
     }
 
     // Test helper handles different file extensions

--- a/tests/Unit/FileHelperRelativeLinkTest.php
+++ b/tests/Unit/FileHelperRelativeLinkTest.php
@@ -91,4 +91,12 @@ class FileHelperRelativeLinkTest extends TestCase
         $this->assertEquals('../', Hyde::relativeLink('index.html', 'foo/bar.html'));
         $this->assertEquals('../../', Hyde::relativeLink('index.html', 'foo/bar/baz.html'));
     }
+
+    public function test_helper_does_not_rewrite_index_when_not_using_pretty_urls()
+    {
+        config(['hyde.prettyUrls' => false]);
+        $this->assertEquals('index.html', Hyde::relativeLink('index.html', 'foo.html'));
+        $this->assertEquals('../index.html', Hyde::relativeLink('index.html', 'foo/bar.html'));
+        $this->assertEquals('../../index.html', Hyde::relativeLink('index.html', 'foo/bar/baz.html'));
+    }
 }

--- a/tests/Unit/FileHelperRelativeLinkTest.php
+++ b/tests/Unit/FileHelperRelativeLinkTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit;
+
+use Hyde\Framework\Hyde;
+use Tests\TestCase;
+
+/**
+ * Class FileHelperRelativeLinkTest.
+ *
+ * @covers \Hyde\Framework\Concerns\Internal\FileHelpers
+ */
+class FileHelperRelativeLinkTest extends TestCase
+{
+    // Test helper returns string as is when $current is not set
+    public function test_helper_returns_string_as_is_if_current_is_not_set()
+    {
+        $this->assertEquals('foo/bar.html', Hyde::relativeLink('foo/bar.html'));
+    }
+
+    // Test helper injects the proper number of `../` 
+    public function test_helper_injects_proper_number_of_doubles_slash()
+    {
+        $this->assertEquals('../index.html', Hyde::relativeLink('index.html', 'foo/bar.html'));
+    }
+
+    // Test helper injects the proper number of `../` for deeply nested $current paths
+    public function test_helper_injects_proper_number_of_doubles_slash_for_deeply_nested_paths()
+    {
+        $this->assertEquals('../../../index.html', Hyde::relativeLink('index.html', 'foo/bar/baz/qux.html'));
+    }
+
+    // Test helper handles destination without file extension
+    public function test_helper_handles_destination_without_file_extension()
+    {
+        $this->assertEquals('../index', Hyde::relativeLink('index', 'foo/bar.html'));
+    }
+
+    // Test helper handles $current without file extension
+    public function test_helper_handles_current_without_file_extension()
+    {
+        $this->assertEquals('../index.html', Hyde::relativeLink('index.html', 'foo/bar'));
+    }
+
+    // Test helper handles case without any file extensions
+    public function test_helper_handles_case_without_any_file_extensions()
+    {
+        $this->assertEquals('../index', Hyde::relativeLink('index', 'foo/bar'));
+    }
+
+    // Test helper handles case with mixed file extensions
+    public function test_helper_handles_case_with_mixed_file_extensions()
+    {
+        $this->assertEquals('../index.md', Hyde::relativeLink('index.md', 'foo/bar.md'));
+        $this->assertEquals('../index.txt', Hyde::relativeLink('index.txt', 'foo/bar.txt'));
+    }
+
+    // Test helper handles different file extensions
+    public function test_helper_handles_different_file_extensions()
+    {
+        $this->assertEquals('../foo.png', Hyde::relativeLink('foo.png', 'foo/bar'));
+        $this->assertEquals('../foo.css', Hyde::relativeLink('foo.css', 'foo/bar'));
+        $this->assertEquals('../foo.js', Hyde::relativeLink('foo.js', 'foo/bar'));
+    }
+}

--- a/tests/Unit/FileHelperRelativeLinkTest.php
+++ b/tests/Unit/FileHelperRelativeLinkTest.php
@@ -62,4 +62,25 @@ class FileHelperRelativeLinkTest extends TestCase
         $this->assertEquals('../foo.css', Hyde::relativeLink('foo.css', 'foo/bar'));
         $this->assertEquals('../foo.js', Hyde::relativeLink('foo.js', 'foo/bar'));
     }
+
+    // Test helper returns pretty URL if enabled and destination is a HTML file
+    public function test_helper_returns_pretty_url_if_enabled_and_destination_is_a_html_file()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('../foo', Hyde::relativeLink('foo.html', 'foo/bar.html'));
+    }
+
+    // Test helper method does not require current path to be HTML to use pretty URLs
+    public function test_helper_method_does_not_require_current_path_to_be_html_to_use_pretty_urls()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('../foo', Hyde::relativeLink('foo.html', 'foo/bar'));
+    }
+
+    // Test helper returns does not return pretty URL if when enabled but and destination is not a HTML file
+    public function test_helper_returns_does_not_return_pretty_url_if_when_enabled_but_and_destination_is_not_a_html_file()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('../foo.png', Hyde::relativeLink('foo.png', 'foo/bar.html'));
+    }
 }

--- a/tests/Unit/HydeFileHelperForPageLinksCanCreatePrettyUrlsTest.php
+++ b/tests/Unit/HydeFileHelperForPageLinksCanCreatePrettyUrlsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit;
+
+use Hyde\Framework\Hyde;
+use Tests\TestCase;
+
+/**
+ * Class HydeFileHelperForPageLinksCanCreatePrettyUrlsTest.
+ *
+ * @covers \Hyde\Framework\Concerns\Internal\FileHelpers
+ */
+class HydeFileHelperForPageLinksCanCreatePrettyUrlsTest extends TestCase
+{
+    public function test_helper_returns_string_as_is_if_pretty_urls_is_not_true()
+    {
+        config(['hyde.prettyUrls' => false]);
+
+        $this->assertEquals('foo/bar.html', Hyde::pageLink('foo/bar.html'));
+    }
+
+    public function test_helper_returns_pretty_url_if_pretty_urls_is_true()
+    {
+        config(['hyde.prettyUrls' => true]);
+
+        $this->assertEquals('foo/bar', Hyde::pageLink('foo/bar.html'));
+    }
+
+    public function test_non_pretty_urls_is_default_value_when_config_is_not_set()
+    {
+        config(['hyde.prettyUrls' => null]);
+
+        $this->assertEquals('foo/bar.html', Hyde::pageLink('foo/bar.html'));
+    }
+
+    public function test_helper_respects_absolute_urls()
+    {
+        config(['hyde.prettyUrls' => false]);
+        $this->assertEquals('/foo/bar.html', Hyde::pageLink('/foo/bar.html'));
+    }
+
+    public function test_helper_respects_pretty_absolute_urls()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('/foo/bar', Hyde::pageLink('/foo/bar.html'));
+    }
+
+    public function test_helper_respects_relative_urls()
+    {
+        config(['hyde.prettyUrls' => false]);
+        $this->assertEquals('../foo/bar.html', Hyde::pageLink('../foo/bar.html'));
+    }
+
+    public function test_helper_respects_pretty_relative_urls()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('../foo/bar', Hyde::pageLink('../foo/bar.html'));
+    }
+
+    public function test_non_html_links_are_not_modified()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('/foo/bar.jpg', Hyde::pageLink('/foo/bar.jpg'));
+    }
+
+    public function test_helper_respects_absolute_urls_with_pretty_urls_enabled()
+    {
+        config(['hyde.prettyUrls' => true]);
+        $this->assertEquals('/foo/bar.jpg', Hyde::pageLink('/foo/bar.jpg'));
+    }
+}

--- a/tests/Unit/TestBuildStaticSiteCommandFlagToEnablePrettyUrls.php
+++ b/tests/Unit/TestBuildStaticSiteCommandFlagToEnablePrettyUrls.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit;
+
+use Hyde\Framework\Hyde;
+use Tests\TestCase;
+
+/**
+ * Class TestBuildStaticSiteCommandFlagToEnablePrettyUrls.
+ */
+class TestBuildStaticSiteCommandFlagToEnablePrettyUrls extends TestCase
+{
+    public function test_pretty_urls_can_be_enabled_with_flag()
+	{
+        config(['hyde.prettyUrls' => false]);
+
+		$this->artisan('build --pretty-urls')
+			->expectsOutput('Generating site with pretty URLs')
+			->assertExitCode(0);
+
+		$this->assertTrue(config('hyde.prettyUrls', false));
+	}
+
+	public function test_config_change_is_not_persisted()
+	{
+		$this->assertFalse(config('hyde.prettyUrls', false));
+	}
+}


### PR DESCRIPTION
## About 
By setting `prettyUrls'` to `true` in the Hyde config, Hyde will now render links without the `.html` file extension.

This is done by using a new pageLink helper. The existing relativeLink used by Hyde includes the new helper by default.
When creating custom Blade pages you can use any of the link helpers to create links where the .html extension is removed depending on the config setting.

Since "pretty URLs" break links when viewing locally, you can keep the setting to the default false, but instead add the `--pretty-urls` option to the `php hyde build` command when you are ready to build for deployment.

## Usage:
```blade
<a href="{{ Hyde::relativeLink('index.html', $currentPage) }}">Back to home page</a>
<a href="{{ Hyde::pageLink('index.html') }}">Back to home page</a>
```
 
## Preview

Live preview at https://hydephp.github.io/developer-tools/pretty-url-test/

## Closes

Will resolve the following:
Fix https://github.com/hydephp/framework/issues/330
Fix https://github.com/hydephp/framework/issues/349
Fix https://github.com/hydephp/framework/issues/353
