### PR TITLE
Load asset service from the service container

### DIFF
--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -147,8 +147,6 @@ class HydeBuildStaticSiteCommand extends Command
     /**
      * Run any post-build actions.
      *
-     * @todo #363 Add unit test for prettier command (can work by comparing compiled baseline to output to see if it was prettified);
-     *
      * @return void
      */
     public function postBuildActions(): void

--- a/src/Concerns/Internal/AssetManager.php
+++ b/src/Concerns/Internal/AssetManager.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Concerns\Internal;
 
+use Hyde\Framework\Contracts\AssetServiceContract;
 use Hyde\Framework\Services\AssetService;
 
 /**
@@ -14,13 +15,11 @@ trait AssetManager
     /**
      * Get the asset service instance.
      *
-     * @todo Refactor to load the service from the container.
-     *
-     * @return \Hyde\Framework\Services\AssetService
+     * @return \Hyde\Framework\Services\AssetServiceContract
      */
-    public static function assetManager(): AssetService
+    public static function assetManager(): AssetServiceContract
     {
-        return new AssetService;
+        return app(AssetServiceContract::class);
     }
 
     /**

--- a/src/HydeServiceProvider.php
+++ b/src/HydeServiceProvider.php
@@ -5,10 +5,12 @@ namespace Hyde\Framework;
 use Composer\InstalledVersions;
 use Hyde\Framework\Actions\CreatesDefaultDirectories;
 use Hyde\Framework\Concerns\RegistersDefaultDirectories;
+use Hyde\Framework\Contracts\AssetServiceContract;
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
+use Hyde\Framework\Services\AssetService;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -44,6 +46,8 @@ class HydeServiceProvider extends ServiceProvider
                 return InstalledVersions::getPrettyVersion('hyde/framework') ?: 'unreleased';
             }
         );
+
+        $this->app->singleton(AssetServiceContract::class, AssetService::class);
 
         $this->registerDefaultDirectories([
             BladePage::class => '_pages',


### PR DESCRIPTION
Resolves a todo related to https://github.com/hydephp/framework/pull/333 and swaps out the getter used to fetch the AssetService to retrieve it from the new Singleton in the service container loaded by the HydeServiceProvider.