### PR TITLE
Fix #379: Extract menu logo to component

### DIFF
--- a/resources/views/components/navigation/navigation-brand.blade.php
+++ b/resources/views/components/navigation/navigation-brand.blade.php
@@ -1,0 +1,3 @@
+<a aria-label="Home page link" href="{{ $homeRoute }}" class="font-bold px-4">
+	{{ config('hyde.name', 'HydePHP') }}
+</a>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -5,9 +5,7 @@ $homeRoute = ($links[array_search('Home', array_column($links, 'title'))])['rout
 
 <nav aria-label="Main navigation" id="main-navigation" class="flex flex-wrap items-center justify-between p-4 shadow-lg sm:shadow-xl md:shadow-none dark:bg-gray-800">
 	<div class="flex flex-grow items-center flex-shrink-0 text-gray-700 dark:text-gray-200">
-		<a aria-label="Home page link" href="{{ $homeRoute }}" class="font-bold px-4">
-			{{ config('hyde.name', 'HydePHP') }}
-		</a>
+		@include('hyde::components.navigation.navigation-brand')
 
 		<div class="ml-auto">
 		@include('hyde::components.navigation.theme-toggle-button')


### PR DESCRIPTION
Fix #379: Extract navigation menu logo to component to make it easier to customize

You can now customize the following component in `@include('hyde::components.navigation.navigation-brand')` 

```blade
<a aria-label="Home page link" href="{{ $homeRoute }}" class="font-bold px-4">
    {{ config('hyde.name', 'HydePHP') }}
</a>
```