### PR TITLE
Add sitemap.xml generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "laravel-zero/framework": "^9.1",
         "league/commonmark": "^2.2",
         "spatie/yaml-front-matter": "^2.0.7",
-        "torchlight/torchlight-commonmark": "^0.5.5"
+        "torchlight/torchlight-commonmark": "^0.5.5",
+      "ext-simplexml": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.0"

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -39,20 +39,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Site URL
+    | Site URL Configuration
     |--------------------------------------------------------------------------
-    |
-    | If you want, you can set your site's URL here or in the .env file.
-    |
-    | The URL will then be used in meta tags to create permalinks.
-    | If you are serving your site from a subdirectory, you will
-    | need to include that in the path without a trailing slash.
-    |
-    | Example: https://example.org/blog
-    |
+    | 
+    | Here are some configuration options for URL generation. 
+    | 
+    | `site_url` is used to create canonical URLs and permalinks.
+    | `prettyUrls` will when enabled create links that do not end in .html.
+    | `generateSitemap` determines if a sitemap.xml file should be generated.
+    | 
+    | To see the full documentation, please visit the (temporary link) below.
+    | https://github.com/hydephp/framework/wiki/Documentation-Page-Drafts
+    | 
+    | 
     */
 
     'site_url' => env('SITE_URL', null),
+
+    'prettyUrls' => false,
+
+    'generateSitemap' => true,
 
     /*
     |--------------------------------------------------------------------------
@@ -279,21 +285,6 @@ return [
         'maxHeadingLevel' => 4,
         'smoothPageScrolling' => true,
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Pretty URLs (Links that do not end in .html)
-    |--------------------------------------------------------------------------
-    |
-    | Introduced in v0.25.0, you can now enable "pretty URLs". When the setting
-    | is enabled, generated links in the compiled HTML site are without the
-    | `.html` extension. Since this breaks local browsing you can leave
-    | the setting disabled, and instead add the `--pretty-urls` flag
-    | when running the `php hyde build` command for deployment.
-    |
-    */
-
-    'prettyUrls' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -67,21 +67,22 @@ class HydeBuildStaticSiteCommand extends Command
 
         $this->transferMediaAssets();
 
-        if (Features::hasBlogPosts()) {
-            $this->runBuildAction(MarkdownPost::class);
+        if (Features::hasBladePages()) {
+            $this->runBuildAction(BladePage::class);
         }
 
         if (Features::hasMarkdownPages()) {
             $this->runBuildAction(MarkdownPage::class);
         }
 
+        if (Features::hasBlogPosts()) {
+            $this->runBuildAction(MarkdownPost::class);
+        }
+
         if (Features::hasDocumentationPages()) {
             $this->runBuildAction(DocumentationPage::class);
         }
 
-        if (Features::hasBladePages()) {
-            $this->runBuildAction(BladePage::class);
-        }
 
         $this->postBuildActions();
 

--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -13,6 +13,7 @@ use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
 use Hyde\Framework\Services\DiscoveryService;
+use Hyde\Framework\Services\SitemapService;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use LaravelZero\Framework\Commands\Command;
@@ -168,6 +169,11 @@ class HydeBuildStaticSiteCommand extends Command
 
         if ($this->option('run-prod')) {
             $this->runNodeCommand('npm run prod', 'Building frontend assets for production!');
+        }
+
+        if (SitemapService::canGenerateSitemap()) {
+            $this->info('Generating sitemap.xml');
+            file_put_contents(Hyde::getSiteOutputPath('sitemap.xml'), SitemapService::generateSitemap());
         }
     }
 

--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -175,6 +175,7 @@ class HydeBuildStaticSiteCommand extends Command
         if (SitemapService::canGenerateSitemap()) {
             $this->info('Generating sitemap.xml');
             file_put_contents(Hyde::getSiteOutputPath('sitemap.xml'), SitemapService::generateSitemap());
+            $this->newLine();
         }
     }
 

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -8,68 +8,62 @@ use Hyde\Framework\Models\BladePage;
 use SimpleXMLElement;
 
 /**
- * @see \Tests\Feature\Services\SitemapServiceTest
- * 
- * @see https://www.sitemaps.org/protocol.html
- */
+* @see \Tests\Feature\Services\SitemapServiceTest
+* 
+* @see https://www.sitemaps.org/protocol.html
+*/
 class SitemapService
 {
     public SimpleXMLElement $xmlElement;
-
+    
     public function __construct()
     {
         $this->time_start = microtime(true);
-
+        
         $this->xmlElement = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"></urlset>');
         $this->xmlElement->addAttribute('generator', 'HydePHP '.Hyde::version());
     }
-
+    
     public function generate(): self
     {
         if (Features::hasBladePages()) {
-            $this->addToSitemap(BladePage::class);
+            $collection = CollectionService::getSourceFileListForModel(BladePage::class);
+            
+            foreach ($collection as $page) {
+                $urlItem = $this->xmlElement->addChild('url');
+                $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
+                $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
+                    Hyde::path(BladePage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.blade.php')
+                )));
+                $urlItem->addChild('changefreq', 'daily');
+            }
         }
-
+        
         return $this;
     }
-
-    public function addToSitemap(string $model): self
-    {
-        $collection = CollectionService::getSourceFileListForModel($model);
-       
-        foreach ($collection as $page) {
-            $urlItem = $this->xmlElement->addChild('url');
-            $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
-            $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
-                Hyde::path(BladePage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.blade.php')
-            )));
-            $urlItem->addChild('changefreq', 'daily');
-        }
-
-        return $this;
-    }
-
+    
+    
     public function getXML(): string
     {
         $this->xmlElement->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2));
-
+        
         return $this->xmlElement->asXML();
     }
-
+    
     public static function generateSitemap(): string
     {
         return (new static)->generate()->getXML();
     }
-
+    
     public static function canGenerateSitemap(): bool
     {
         return (Hyde::uriPath() !== false);
     }
-
+    
     protected function getLastModDateForFileOrFallback(string $filepath): string
     {
         return file_exists($filepath)
-            ? date('c', filemtime($filepath))
-            : date('c');
+        ? date('c', filemtime($filepath))
+        : date('c');
     }
 }

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -36,7 +36,11 @@ class SitemapService
         $collection = CollectionService::getSourceFileListForModel($model);
        
         foreach ($collection as $page) {
-            $this->xmlElement->addChild('url')->addChild('loc', Hyde::uriPath(Hyde::pageLink($page . '.html')));
+            $urlItem = $this->xmlElement->addChild('url');
+            $urlItem->addChild('loc', Hyde::uriPath(Hyde::pageLink($page . '.html')));
+            $urlItem->addChild('lastmod', date('c', filemtime(
+                Hyde::path(BladePage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.blade.php')
+            )));
         }
 
         return $this;

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Hyde\Framework\Services;
+
+use Hyde\Framework\Helpers\Features;
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\BladePage;
+use SimpleXMLElement;
+
+/**
+ * @see \Tests\Feature\Services\SitemapServiceTest
+ */
+class SitemapService
+{
+    public SimpleXMLElement $xmlElement;
+
+    public function __construct()
+    {
+        $this->time_start = microtime(true);
+
+        $this->xmlElement = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"></urlset>');
+        $this->xmlElement->addAttribute('generator', 'HydePHP '.Hyde::version());
+    }
+
+    public function generate(): self
+    {
+        if (Features::hasBladePages()) {
+            $this->addToSitemap(BladePage::class);
+        }
+
+        return $this;
+    }
+
+    public function addToSitemap(string $model): self
+    {
+        $collection = CollectionService::getSourceFileListForModel($model);
+       
+        foreach ($collection as $page) {
+            $this->xmlElement->addChild('url')->addChild('loc', Hyde::uriPath(Hyde::pageLink($page . '.html')));
+        }
+
+        return $this;
+    }
+
+    public function getXML(): string
+    {
+        $this->xmlElement->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2));
+
+        return $this->xmlElement->asXML();
+    }
+
+    public static function generateSitemap(): string
+    {
+        return (new static)->generate()->getXML();
+    }
+
+    public static function canGenerateSitemap(): bool
+    {
+        return (Hyde::uriPath() !== false);
+    }
+}

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -9,6 +9,8 @@ use SimpleXMLElement;
 
 /**
  * @see \Tests\Feature\Services\SitemapServiceTest
+ * 
+ * @see https://www.sitemaps.org/protocol.html
  */
 class SitemapService
 {

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -39,10 +39,10 @@ class SitemapService
        
         foreach ($collection as $page) {
             $urlItem = $this->xmlElement->addChild('url');
-            $urlItem->addChild('loc', Hyde::uriPath(Hyde::pageLink($page . '.html')));
-            $urlItem->addChild('lastmod', date('c', filemtime(
+            $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
+            $urlItem->addChild('lastmod', htmlentities(date('c', filemtime(
                 Hyde::path(BladePage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.blade.php')
-            )));
+            ))));
             $urlItem->addChild('changefreq', 'daily');
         }
 

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -72,16 +72,16 @@ class SitemapService
         foreach ($collection as $page) {
             $urlItem = $this->xmlElement->addChild('url');
             $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($routePrefix.$page . '.html'))));
-            $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
-                Hyde::path($pageClass::$sourceDirectory.DIRECTORY_SEPARATOR.$page.$pageClass::$fileExtension)
-            )));
+            $urlItem->addChild('lastmod', htmlentities($this->getLastModDate($pageClass, $page)));
             $urlItem->addChild('changefreq', 'daily');
         }
     }
 
-    protected function getLastModDate(string $filepath): string
+    protected function getLastModDate(string $pageClass, string $page): string
     {
-        return date('c', filemtime($filepath));
+        return date('c', filemtime(
+            Hyde::path($pageClass::$sourceDirectory.DIRECTORY_SEPARATOR.$page.$pageClass::$fileExtension)
+        ));
     }
 
     public static function generateSitemap(): string

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -40,9 +40,9 @@ class SitemapService
         foreach ($collection as $page) {
             $urlItem = $this->xmlElement->addChild('url');
             $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
-            $urlItem->addChild('lastmod', htmlentities(date('c', filemtime(
+            $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
                 Hyde::path(BladePage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.blade.php')
-            ))));
+            )));
             $urlItem->addChild('changefreq', 'daily');
         }
 
@@ -64,5 +64,12 @@ class SitemapService
     public static function canGenerateSitemap(): bool
     {
         return (Hyde::uriPath() !== false);
+    }
+
+    protected function getLastModDateForFileOrFallback(string $filepath): string
+    {
+        return file_exists($filepath)
+            ? date('c', filemtime($filepath))
+            : date('c');
     }
 }

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -6,6 +6,7 @@ use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\MarkdownPage;
+use Hyde\Framework\Models\MarkdownPost;
 use SimpleXMLElement;
 
 /**
@@ -52,6 +53,19 @@ class SitemapService
                 $urlItem->addChild('changefreq', 'daily');
             }
         }
+
+        if (Features::hasBlogPosts()) {
+            $collection = CollectionService::getSourceFileListForModel(MarkdownPost::class);
+            
+            foreach ($collection as $page) {
+                $urlItem = $this->xmlElement->addChild('url');
+                $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink('posts/'.$page . '.html'))));
+                $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
+                    Hyde::path(MarkdownPost::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
+                )));
+                $urlItem->addChild('changefreq', 'daily');
+            }
+        }
         
         return $this;
     }
@@ -78,6 +92,6 @@ class SitemapService
     {
         return file_exists($filepath)
         ? date('c', filemtime($filepath))
-        : date('c');
+        : 'null' ; // ?? date('c')
     }
 }

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -41,6 +41,7 @@ class SitemapService
             $urlItem->addChild('lastmod', date('c', filemtime(
                 Hyde::path(BladePage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.blade.php')
             )));
+            $urlItem->addChild('changefreq', 'daily');
         }
 
         return $this;

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -92,21 +92,21 @@ class SitemapService
         
         return $this->xmlElement->asXML();
     }
-    
-    public static function generateSitemap(): string
-    {
-        return (new static)->generate()->getXML();
-    }
-    
-    public static function canGenerateSitemap(): bool
-    {
-        return (Hyde::uriPath() !== false);
-    }
-    
+
     protected function getLastModDateForFileOrFallback(string $filepath): string
     {
         return file_exists($filepath)
         ? date('c', filemtime($filepath))
-        : 'null' ; // ?? date('c')
+        : date('c');
+    }
+
+    public static function generateSitemap(): string
+    {
+        return (new static)->generate()->getXML();
+    }
+
+    public static function canGenerateSitemap(): bool
+    {
+        return (Hyde::uriPath() !== false);
     }
 }

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -5,6 +5,7 @@ namespace Hyde\Framework\Services;
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;
+use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
 use SimpleXMLElement;
@@ -62,6 +63,20 @@ class SitemapService
                 $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink('posts/'.$page . '.html'))));
                 $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
                     Hyde::path(MarkdownPost::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
+                )));
+                $urlItem->addChild('changefreq', 'daily');
+            }
+        }
+
+        
+        if (Features::hasDocumentationPages()) {
+            $collection = CollectionService::getSourceFileListForModel(DocumentationPage::class);
+            
+            foreach ($collection as $page) {
+                $urlItem = $this->xmlElement->addChild('url');
+                $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink(Hyde::docsDirectory().'/'.$page . '.html'))));
+                $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
+                    Hyde::path(DocumentationPage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
                 )));
                 $urlItem->addChild('changefreq', 'daily');
             }

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -91,6 +91,6 @@ class SitemapService
 
     public static function canGenerateSitemap(): bool
     {
-        return (Hyde::uriPath() !== false);
+        return (Hyde::uriPath() !== false) && config('hyde.generateSitemap', true);
     }
 }

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -30,55 +30,29 @@ class SitemapService
     public function generate(): self
     {
         if (Features::hasBladePages()) {
-            $collection = CollectionService::getSourceFileListForModel(BladePage::class);
-            
-            foreach ($collection as $page) {
-                $urlItem = $this->xmlElement->addChild('url');
-                $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
-                $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
-                    Hyde::path(BladePage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.blade.php')
-                )));
-                $urlItem->addChild('changefreq', 'daily');
-            }
+            $this->addPageModelUrls(
+                BladePage::class
+            );
         }
 
         if (Features::hasMarkdownPages()) {
-            $collection = CollectionService::getSourceFileListForModel(MarkdownPage::class);
-            
-            foreach ($collection as $page) {
-                $urlItem = $this->xmlElement->addChild('url');
-                $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
-                $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
-                    Hyde::path(MarkdownPage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
-                )));
-                $urlItem->addChild('changefreq', 'daily');
-            }
+            $this->addPageModelUrls(
+                MarkdownPage::class
+            );
         }
 
         if (Features::hasBlogPosts()) {
-            $collection = CollectionService::getSourceFileListForModel(MarkdownPost::class);
-            
-            foreach ($collection as $page) {
-                $urlItem = $this->xmlElement->addChild('url');
-                $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink('posts/'.$page . '.html'))));
-                $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
-                    Hyde::path(MarkdownPost::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
-                )));
-                $urlItem->addChild('changefreq', 'daily');
-            }
+            $this->addPageModelUrls(
+                MarkdownPost::class,
+                'posts/'
+            );
         }
 
         if (Features::hasDocumentationPages()) {
-            $collection = CollectionService::getSourceFileListForModel(DocumentationPage::class);
-            
-            foreach ($collection as $page) {
-                $urlItem = $this->xmlElement->addChild('url');
-                $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink(Hyde::docsDirectory().'/'.$page . '.html'))));
-                $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
-                    Hyde::path(DocumentationPage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
-                )));
-                $urlItem->addChild('changefreq', 'daily');
-            }
+            $this->addPageModelUrls(
+                DocumentationPage::class,
+                Hyde::docsDirectory().'/'
+            );
         }
         
         return $this;
@@ -89,6 +63,20 @@ class SitemapService
         $this->xmlElement->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2));
         
         return $this->xmlElement->asXML();
+    }
+
+    public function addPageModelUrls(string $pageClass, string $routePrefix = ''): void
+    {
+        $collection = CollectionService::getSourceFileListForModel($pageClass);
+
+        foreach ($collection as $page) {
+            $urlItem = $this->xmlElement->addChild('url');
+            $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($routePrefix.$page . '.html'))));
+            $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
+                Hyde::path($pageClass::$sourceDirectory.DIRECTORY_SEPARATOR.$page.$pageClass::$fileExtension)
+            )));
+            $urlItem->addChild('changefreq', 'daily');
+        }
     }
 
     protected function getLastModDate(string $filepath): string

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -5,6 +5,7 @@ namespace Hyde\Framework\Services;
 use Hyde\Framework\Helpers\Features;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;
+use Hyde\Framework\Models\MarkdownPage;
 use SimpleXMLElement;
 
 /**
@@ -34,6 +35,19 @@ class SitemapService
                 $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
                 $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
                     Hyde::path(BladePage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.blade.php')
+                )));
+                $urlItem->addChild('changefreq', 'daily');
+            }
+        }
+
+        if (Features::hasMarkdownPages()) {
+            $collection = CollectionService::getSourceFileListForModel(MarkdownPage::class);
+            
+            foreach ($collection as $page) {
+                $urlItem = $this->xmlElement->addChild('url');
+                $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
+                $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
+                    Hyde::path(MarkdownPage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
                 )));
                 $urlItem->addChild('changefreq', 'daily');
             }

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -35,7 +35,7 @@ class SitemapService
             foreach ($collection as $page) {
                 $urlItem = $this->xmlElement->addChild('url');
                 $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
-                $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
+                $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
                     Hyde::path(BladePage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.blade.php')
                 )));
                 $urlItem->addChild('changefreq', 'daily');
@@ -48,7 +48,7 @@ class SitemapService
             foreach ($collection as $page) {
                 $urlItem = $this->xmlElement->addChild('url');
                 $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($page . '.html'))));
-                $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
+                $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
                     Hyde::path(MarkdownPage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
                 )));
                 $urlItem->addChild('changefreq', 'daily');
@@ -61,21 +61,20 @@ class SitemapService
             foreach ($collection as $page) {
                 $urlItem = $this->xmlElement->addChild('url');
                 $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink('posts/'.$page . '.html'))));
-                $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
+                $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
                     Hyde::path(MarkdownPost::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
                 )));
                 $urlItem->addChild('changefreq', 'daily');
             }
         }
 
-        
         if (Features::hasDocumentationPages()) {
             $collection = CollectionService::getSourceFileListForModel(DocumentationPage::class);
             
             foreach ($collection as $page) {
                 $urlItem = $this->xmlElement->addChild('url');
                 $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink(Hyde::docsDirectory().'/'.$page . '.html'))));
-                $urlItem->addChild('lastmod', htmlentities($this->getLastModDateForFileOrFallback(
+                $urlItem->addChild('lastmod', htmlentities($this->getLastModDate(
                     Hyde::path(DocumentationPage::$sourceDirectory.DIRECTORY_SEPARATOR.$page.'.md')
                 )));
                 $urlItem->addChild('changefreq', 'daily');
@@ -85,7 +84,6 @@ class SitemapService
         return $this;
     }
     
-    
     public function getXML(): string
     {
         $this->xmlElement->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2));
@@ -93,11 +91,9 @@ class SitemapService
         return $this->xmlElement->asXML();
     }
 
-    protected function getLastModDateForFileOrFallback(string $filepath): string
+    protected function getLastModDate(string $filepath): string
     {
-        return file_exists($filepath)
-        ? date('c', filemtime($filepath))
-        : date('c');
+        return date('c', filemtime($filepath));
     }
 
     public static function generateSitemap(): string

--- a/src/Services/SitemapService.php
+++ b/src/Services/SitemapService.php
@@ -69,18 +69,18 @@ class SitemapService
     {
         $collection = CollectionService::getSourceFileListForModel($pageClass);
 
-        foreach ($collection as $page) {
+        foreach ($collection as $slug) {
             $urlItem = $this->xmlElement->addChild('url');
-            $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($routePrefix.$page . '.html'))));
-            $urlItem->addChild('lastmod', htmlentities($this->getLastModDate($pageClass, $page)));
+            $urlItem->addChild('loc', htmlentities(Hyde::uriPath(Hyde::pageLink($routePrefix.$slug . '.html'))));
+            $urlItem->addChild('lastmod', htmlentities($this->getLastModDate($pageClass, $slug)));
             $urlItem->addChild('changefreq', 'daily');
         }
     }
 
-    protected function getLastModDate(string $pageClass, string $page): string
+    protected function getLastModDate(string $pageClass, string $slug): string
     {
         return date('c', filemtime(
-            Hyde::path($pageClass::$sourceDirectory.DIRECTORY_SEPARATOR.$page.$pageClass::$fileExtension)
+            Hyde::path($pageClass::$sourceDirectory.DIRECTORY_SEPARATOR.$slug.$pageClass::$fileExtension)
         ));
     }
 

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -86,6 +86,13 @@ class BuildStaticSiteCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
+    public function test_pretty_urls_option_output()
+    {
+        $this->artisan('build --pretty-urls')
+            ->expectsOutput('Generating site with pretty URLs')
+            ->assertExitCode(0);
+    }
+
     /**
      * Added for code coverage, deprecated as the pretty flag is deprecated.
      *

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -93,6 +93,31 @@ class BuildStaticSiteCommandTest extends TestCase
             ->assertExitCode(0);
     }
 
+    public function test_sitemap_is_not_generated_when_conditions_are_not_met()
+    {
+        config(['hyde.site_url' => '']);
+        config(['hyde.generateSitemap' => false]);
+
+        unlinkIfExists(Hyde::path('_site/sitemap.xml'));
+        $this->artisan('build')
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist(Hyde::path('_site/sitemap.xml'));
+    }
+
+    public function test_sitemap_is_generated_when_conditions_are_met()
+    {
+        config(['hyde.site_url' => 'https://example.com']);
+        config(['hyde.generateSitemap' => true]);
+
+        unlinkIfExists(Hyde::path('_site/sitemap.xml'));
+        $this->artisan('build')
+            ->expectsOutput('Generating sitemap.xml')
+            ->assertExitCode(0);
+
+        $this->assertFileExists(Hyde::path('_site/sitemap.xml'));
+    }
+
     /**
      * Added for code coverage, deprecated as the pretty flag is deprecated.
      *

--- a/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
+++ b/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
@@ -90,14 +90,48 @@ class SitemapServiceTest extends TestCase
     // Test canGenerateSitemap helper returns true if Hyde has a base URL
     public function testCanGenerateSitemapHelperReturnsTrueIfHydeHasBaseUrl()
     {
-        $this->app['config']->set('hyde.site_url', 'foo');
+        config(['hyde.site_url' => 'foo']);
         $this->assertTrue(SitemapService::canGenerateSitemap());
     }
 
     // Test canGenerateSitemap helper returns false if Hyde does not have a base URL
     public function testCanGenerateSitemapHelperReturnsFalseIfHydeDoesNotHaveBaseUrl()
     {
-        $this->app['config']->set('hyde.site_url', '');
+        config(['hyde.site_url' => '']);
         $this->assertFalse(SitemapService::canGenerateSitemap());
+    }
+
+    // Test URL item is generated correctly
+    public function testURLItemIsGeneratedCorrectly()
+    {
+        config(['hyde.prettyUrls' => false]);
+        config(['hyde.site_url' => 'https://example.com']);
+        touch(Hyde::path('_pages/0-test.blade.php'));
+
+        $service = new SitemapService();
+        $service->generate();
+
+        $url = $service->xmlElement->url[0];
+        $this->assertEquals('https://example.com/0-test.html', $url->loc);
+        $this->assertEquals('daily', $url->changefreq);
+        $this->assertEquals(date('c'), $url->lastmod);
+
+        unlink(Hyde::path('_pages/0-test.blade.php'));
+    }
+
+    // Test URL item is generated with pretty URLs if enabled
+    public function testURLItemIsGeneratedWithPrettyURLsIfEnabled()
+    {
+        config(['hyde.prettyUrls' => true]);
+        config(['hyde.site_url' => 'https://example.com']);
+        touch(Hyde::path('_pages/0-test.blade.php'));
+
+        $service = new SitemapService();
+        $service->generate();
+
+        $url = $service->xmlElement->url[0];
+        $this->assertEquals('https://example.com/0-test', $url->loc);
+
+        unlink(Hyde::path('_pages/0-test.blade.php'));
     }
 }

--- a/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
+++ b/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
@@ -101,6 +101,14 @@ class SitemapServiceTest extends TestCase
         $this->assertFalse(SitemapService::canGenerateSitemap());
     }
 
+    // Test canGenerateSitemap helper returns false if sitemaps are disabled in config
+    public function testCanGenerateSitemapHelperReturnsFalseIfSitemapsAreDisabledInConfig()
+    {
+        config(['hyde.site_url' => 'foo']);
+        config(['hyde.generateSitemap' => false]);
+        $this->assertFalse(SitemapService::canGenerateSitemap());
+    }
+
     // Test URL item is generated correctly
     public function testURLItemIsGeneratedCorrectly()
     {

--- a/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
+++ b/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Services\SitemapServiceTest;
 
+use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\SitemapService;
 use Tests\TestCase;
 
@@ -10,5 +11,93 @@ use Tests\TestCase;
  */
 class SitemapServiceTest extends TestCase
 {
+    // Test service instantiates an XML element
+    public function testServiceInstantiatesXmlElement()
+    {
+        $service = new SitemapService();
+        $this->assertInstanceOf('SimpleXMLElement', $service->xmlElement);
+    }
 
+    // Test generate method adds default pages to sitemap XML
+    public function testGenerateAddsDefaultPagesToXml()
+    {
+        $service = new SitemapService();
+        $service->generate();
+
+        // Test runner has an index and 404 page, so we are using that as a baseline
+        $this->assertCount(2, $service->xmlElement->url);
+    }
+
+    // Test generate method adds Markdown pages to sitemap XML
+    public function testGenerateAddsMarkdownPagesToXml()
+    {
+        touch(Hyde::path('_pages/foo.md'));
+
+        $service = new SitemapService();
+        $service->generate();
+
+        $this->assertCount(3, $service->xmlElement->url);
+
+        unlink(Hyde::path('_pages/foo.md'));
+    }
+
+    // Test generate method adds Markdown posts to sitemap XML
+    public function testGenerateAddsMarkdownPostsToXml()
+    {
+        touch(Hyde::path('_posts/foo.md'));
+
+        $service = new SitemapService();
+        $service->generate();
+
+        $this->assertCount(3, $service->xmlElement->url);
+
+        unlink(Hyde::path('_posts/foo.md'));
+    }
+
+    // Test generate method adds documentation pages to sitemap XML
+    public function testGenerateAddsDocumentationPagesToXml()
+    {
+        touch(Hyde::path('_docs/foo.md'));
+
+        $service = new SitemapService();
+        $service->generate();
+
+        $this->assertCount(3, $service->xmlElement->url);
+
+        unlink(Hyde::path('_docs/foo.md'));
+    }
+
+    // Test getXML method returns XML string
+    public function testGetXMLReturnsXMLString()
+    {
+        $service = new SitemapService();
+        $service->generate();
+        $xml = $service->getXML();
+
+        $this->assertIsString($xml);
+        $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $xml);
+    }
+
+    // Test generateSitemap shorthand method returns XML string
+    public function testGenerateSitemapShorthandMethodReturnsXMLString()
+    {
+        $xml = SitemapService::generateSitemap();
+
+        $this->assertIsString($xml);
+        $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $xml);
+    }
+
+    // Test canGenerateSitemap helper returns true if Hyde has a base URL
+    public function testCanGenerateSitemapHelperReturnsTrueIfHydeHasBaseUrl()
+    {
+        $this->app['config']->set('hyde.site_url', 'foo');
+        $this->assertTrue(SitemapService::canGenerateSitemap());
+    }
+
+    // Test canGenerateSitemap helper returns false if Hyde does not have a base URL
+    public function testCanGenerateSitemapHelperReturnsFalseIfHydeDoesNotHaveBaseUrl()
+    {
+        $this->app['config']->set('hyde.site_url', '');
+        $this->assertFalse(SitemapService::canGenerateSitemap());
+    }
 }

--- a/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
+++ b/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Feature\Services\SitemapServiceTest;
+
+use Hyde\Framework\Services\SitemapService;
+use Tests\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Services\SitemapService
+ */
+class SitemapServiceTest extends TestCase
+{
+
+}

--- a/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
+++ b/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
@@ -12,14 +12,14 @@ use Tests\TestCase;
 class SitemapServiceTest extends TestCase
 {
     // Test service instantiates an XML element
-    public function testServiceInstantiatesXmlElement()
+    public function test_service_instantiates_xml_element()
     {
         $service = new SitemapService();
         $this->assertInstanceOf('SimpleXMLElement', $service->xmlElement);
     }
 
     // Test generate method adds default pages to sitemap XML
-    public function testGenerateAddsDefaultPagesToXml()
+    public function test_generate_adds_default_pages_to_xml()
     {
         $service = new SitemapService();
         $service->generate();
@@ -29,7 +29,7 @@ class SitemapServiceTest extends TestCase
     }
 
     // Test generate method adds Markdown pages to sitemap XML
-    public function testGenerateAddsMarkdownPagesToXml()
+    public function test_generate_adds_markdown_pages_to_xml()
     {
         touch(Hyde::path('_pages/foo.md'));
 
@@ -42,7 +42,7 @@ class SitemapServiceTest extends TestCase
     }
 
     // Test generate method adds Markdown posts to sitemap XML
-    public function testGenerateAddsMarkdownPostsToXml()
+    public function test_generate_adds_markdown_posts_to_xml()
     {
         touch(Hyde::path('_posts/foo.md'));
 
@@ -55,7 +55,7 @@ class SitemapServiceTest extends TestCase
     }
 
     // Test generate method adds documentation pages to sitemap XML
-    public function testGenerateAddsDocumentationPagesToXml()
+    public function test_generate_adds_documentation_pages_to_xml()
     {
         touch(Hyde::path('_docs/foo.md'));
 
@@ -68,7 +68,7 @@ class SitemapServiceTest extends TestCase
     }
 
     // Test getXML method returns XML string
-    public function testGetXMLReturnsXMLString()
+    public function test_get_xml_returns_xml_string()
     {
         $service = new SitemapService();
         $service->generate();
@@ -79,7 +79,7 @@ class SitemapServiceTest extends TestCase
     }
 
     // Test generateSitemap shorthand method returns XML string
-    public function testGenerateSitemapShorthandMethodReturnsXMLString()
+    public function test_generate_sitemap_shorthand_method_returns_xml_string()
     {
         $xml = SitemapService::generateSitemap();
 
@@ -88,21 +88,21 @@ class SitemapServiceTest extends TestCase
     }
 
     // Test canGenerateSitemap helper returns true if Hyde has a base URL
-    public function testCanGenerateSitemapHelperReturnsTrueIfHydeHasBaseUrl()
+    public function test_can_generate_sitemap_helper_returns_true_if_hyde_has_base_url()
     {
         config(['hyde.site_url' => 'foo']);
         $this->assertTrue(SitemapService::canGenerateSitemap());
     }
 
     // Test canGenerateSitemap helper returns false if Hyde does not have a base URL
-    public function testCanGenerateSitemapHelperReturnsFalseIfHydeDoesNotHaveBaseUrl()
+    public function test_can_generate_sitemap_helper_returns_false_if_hyde_does_not_have_base_url()
     {
         config(['hyde.site_url' => '']);
         $this->assertFalse(SitemapService::canGenerateSitemap());
     }
 
     // Test canGenerateSitemap helper returns false if sitemaps are disabled in config
-    public function testCanGenerateSitemapHelperReturnsFalseIfSitemapsAreDisabledInConfig()
+    public function test_can_generate_sitemap_helper_returns_false_if_sitemaps_are_disabled_in_config()
     {
         config(['hyde.site_url' => 'foo']);
         config(['hyde.generateSitemap' => false]);
@@ -110,7 +110,7 @@ class SitemapServiceTest extends TestCase
     }
 
     // Test URL item is generated correctly
-    public function testURLItemIsGeneratedCorrectly()
+    public function test_url_item_is_generated_correctly()
     {
         config(['hyde.prettyUrls' => false]);
         config(['hyde.site_url' => 'https://example.com']);
@@ -128,7 +128,7 @@ class SitemapServiceTest extends TestCase
     }
 
     // Test URL item is generated with pretty URLs if enabled
-    public function testURLItemIsGeneratedWithPrettyURLsIfEnabled()
+    public function test_url_item_is_generated_with_pretty_ur_ls_if_enabled()
     {
         config(['hyde.prettyUrls' => true]);
         config(['hyde.site_url' => 'https://example.com']);

--- a/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
+++ b/tests/Feature/Services/SitemapServiceTest/SitemapServiceTest.php
@@ -11,14 +11,12 @@ use Tests\TestCase;
  */
 class SitemapServiceTest extends TestCase
 {
-    // Test service instantiates an XML element
     public function test_service_instantiates_xml_element()
     {
         $service = new SitemapService();
         $this->assertInstanceOf('SimpleXMLElement', $service->xmlElement);
     }
 
-    // Test generate method adds default pages to sitemap XML
     public function test_generate_adds_default_pages_to_xml()
     {
         $service = new SitemapService();
@@ -28,7 +26,6 @@ class SitemapServiceTest extends TestCase
         $this->assertCount(2, $service->xmlElement->url);
     }
 
-    // Test generate method adds Markdown pages to sitemap XML
     public function test_generate_adds_markdown_pages_to_xml()
     {
         touch(Hyde::path('_pages/foo.md'));
@@ -41,7 +38,6 @@ class SitemapServiceTest extends TestCase
         unlink(Hyde::path('_pages/foo.md'));
     }
 
-    // Test generate method adds Markdown posts to sitemap XML
     public function test_generate_adds_markdown_posts_to_xml()
     {
         touch(Hyde::path('_posts/foo.md'));
@@ -54,7 +50,6 @@ class SitemapServiceTest extends TestCase
         unlink(Hyde::path('_posts/foo.md'));
     }
 
-    // Test generate method adds documentation pages to sitemap XML
     public function test_generate_adds_documentation_pages_to_xml()
     {
         touch(Hyde::path('_docs/foo.md'));
@@ -67,7 +62,6 @@ class SitemapServiceTest extends TestCase
         unlink(Hyde::path('_docs/foo.md'));
     }
 
-    // Test getXML method returns XML string
     public function test_get_xml_returns_xml_string()
     {
         $service = new SitemapService();
@@ -78,7 +72,6 @@ class SitemapServiceTest extends TestCase
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $xml);
     }
 
-    // Test generateSitemap shorthand method returns XML string
     public function test_generate_sitemap_shorthand_method_returns_xml_string()
     {
         $xml = SitemapService::generateSitemap();
@@ -87,21 +80,18 @@ class SitemapServiceTest extends TestCase
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', $xml);
     }
 
-    // Test canGenerateSitemap helper returns true if Hyde has a base URL
     public function test_can_generate_sitemap_helper_returns_true_if_hyde_has_base_url()
     {
         config(['hyde.site_url' => 'foo']);
         $this->assertTrue(SitemapService::canGenerateSitemap());
     }
 
-    // Test canGenerateSitemap helper returns false if Hyde does not have a base URL
     public function test_can_generate_sitemap_helper_returns_false_if_hyde_does_not_have_base_url()
     {
         config(['hyde.site_url' => '']);
         $this->assertFalse(SitemapService::canGenerateSitemap());
     }
 
-    // Test canGenerateSitemap helper returns false if sitemaps are disabled in config
     public function test_can_generate_sitemap_helper_returns_false_if_sitemaps_are_disabled_in_config()
     {
         config(['hyde.site_url' => 'foo']);
@@ -109,7 +99,6 @@ class SitemapServiceTest extends TestCase
         $this->assertFalse(SitemapService::canGenerateSitemap());
     }
 
-    // Test URL item is generated correctly
     public function test_url_item_is_generated_correctly()
     {
         config(['hyde.prettyUrls' => false]);
@@ -127,7 +116,6 @@ class SitemapServiceTest extends TestCase
         unlink(Hyde::path('_pages/0-test.blade.php'));
     }
 
-    // Test URL item is generated with pretty URLs if enabled
     public function test_url_item_is_generated_with_pretty_ur_ls_if_enabled()
     {
         config(['hyde.prettyUrls' => true]);


### PR DESCRIPTION
## About

When a site_url is set, (and the feature is not disabled in the config), a sitemap.xml will automatically be generated during the static site building process.

## Features

- Adds sitemap.xml generation

## Changes

- `ext-simplexml` has been added as a requirement to `composer.json`
- The order of page builders have been changed, so that Blade and Markdown pages are compiled first.
  This allows you to browse the most common parts of the site (like the index page) while the other
  pages are being generated.
- Merge "Site URL Configuration" options. Please republish your configs.
