### PR TITLE
Fix #403: Remove @HydeConfigVersion annotation from config/hyde.php

### DIFF
--- a/config/hyde.php
+++ b/config/hyde.php
@@ -288,12 +288,11 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Hyde Config Version @HydeConfigVersion 0.1.0
+    | Warn about outdated config? 
     |--------------------------------------------------------------------------
     |
-    | Hyde can use the value above to determine if this configuration file
-    | contains the latest config options. If your config needs updating,
-    | a message will be shown in the HydeCLI, unless disabled below.
+    | If your config needs updating, a message will be shown in the
+    | HydeCLI info screen, unless disabled below.
     |
     */
 


### PR DESCRIPTION
Removes the annotation and rewrites the inline documentation. There are no functional or behavioral changes affected by this.