### PR TITLE
Add RSS feed for Markdown blog posts

### DIFF
--- a/config/hyde.php
+++ b/config/hyde.php
@@ -44,6 +44,8 @@ return [
     |
     | Here are some configuration options for URL generation.
     |
+    | A site_url is required to use sitemaps and RSS feeds.
+    |
     | `site_url` is used to create canonical URLs and permalinks.
     | `prettyUrls` will when enabled create links that do not end in .html.
     | `generateSitemap` determines if a sitemap.xml file should be generated.

--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -173,16 +173,17 @@ class HydeBuildStaticSiteCommand extends Command
         }
 
         if (SitemapService::canGenerateSitemap()) {
-            $this->info('Generating sitemap.xml');
+            $actionTime = microtime(true);
+            $this->comment('Generating sitemap...');
             file_put_contents(Hyde::getSiteOutputPath('sitemap.xml'), SitemapService::generateSitemap());
-            $this->newLine();
+            $this->line(' > Created <info>sitemap.xml</> in ' .$this->getExecutionTimeInMs($actionTime)."ms\n");
         }
 
         if (RssFeedService::canGenerateFeed()) {
-            $this->info('Generating RSS feed');
-            
+            $actionTime = microtime(true);
+            $this->comment('Generating RSS feed...');
             file_put_contents(Hyde::getSiteOutputPath(RssFeedService::getDefaultOutputFilename()), RssFeedService::generateFeed());
-            $this->newLine();
+            $this->line(' > Created <info>'.RssFeedService::getDefaultOutputFilename().'</> in ' .$this->getExecutionTimeInMs($actionTime)."ms\n");
         }
     }
 
@@ -205,5 +206,10 @@ class HydeBuildStaticSiteCommand extends Command
         $this->line(
             $output ?? '<fg=red>Could not '.($actionMessage ?? 'run script').'! Is NPM installed?</>'
         );
+    }
+
+    protected function getExecutionTimeInMs(float $timeStart): float
+    {
+        return number_format(((microtime(true) - $timeStart) * 1000), 2);
     }
 }

--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -13,6 +13,7 @@ use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\MarkdownPage;
 use Hyde\Framework\Models\MarkdownPost;
 use Hyde\Framework\Services\DiscoveryService;
+use Hyde\Framework\Services\RssFeedService;
 use Hyde\Framework\Services\SitemapService;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
@@ -174,6 +175,13 @@ class HydeBuildStaticSiteCommand extends Command
         if (SitemapService::canGenerateSitemap()) {
             $this->info('Generating sitemap.xml');
             file_put_contents(Hyde::getSiteOutputPath('sitemap.xml'), SitemapService::generateSitemap());
+            $this->newLine();
+        }
+
+        if (RssFeedService::canGenerateFeed()) {
+            $this->info('Generating RSS feed');
+            
+            file_put_contents(Hyde::getSiteOutputPath(RssFeedService::getDefaultOutputFilename()), RssFeedService::generateFeed());
             $this->newLine();
         }
     }

--- a/src/Models/Author.php
+++ b/src/Models/Author.php
@@ -47,4 +47,14 @@ class Author
             $this->website = $data['website'];
         }
     }
+
+    /**
+     * Get the author's name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name ?? $this->username;
+    }
 }

--- a/src/Models/MarkdownPost.php
+++ b/src/Models/MarkdownPost.php
@@ -42,4 +42,9 @@ class MarkdownPost extends MarkdownDocument
     {
         return Hyde::uriPath(Hyde::pageLink($this->getCurrentPagePath().'.html'));
     }
+
+    public function getPostDescription(): string
+    {
+        return $this->matter['description'] ?? substr($this->body, 0, 125).'...';
+    }
 }

--- a/src/Models/MarkdownPost.php
+++ b/src/Models/MarkdownPost.php
@@ -6,6 +6,7 @@ use Hyde\Framework\Concerns\GeneratesPageMetadata;
 use Hyde\Framework\Concerns\HasAuthor;
 use Hyde\Framework\Concerns\HasDateString;
 use Hyde\Framework\Concerns\HasFeaturedImage;
+use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Parsers\MarkdownPostParser;
 
 class MarkdownPost extends MarkdownDocument
@@ -35,5 +36,10 @@ class MarkdownPost extends MarkdownDocument
     public function getCurrentPagePath(): string
     {
         return 'posts/'.$this->slug;
+    }
+
+    public function getCanonicalLink(): string
+    {
+        return Hyde::uriPath(Hyde::pageLink($this->getCurrentPagePath().'.html'));
     }
 }

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Hyde\Framework\Services;
+
+class RssFeedService
+{
+	
+}
+

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -47,6 +47,15 @@ class RssFeedService
         $item->addChild('title', $post->findTitleForDocument());
         $item->addChild('link', $post->getCanonicalLink());
         $item->addChild('description', $post->getPostDescription());
+
+        $this->addAdditionalItemData($item, $post);
+    }
+
+    protected function addAdditionalItemData(SimpleXMLElement $item, MarkdownPost $post): void
+    {
+        if ($post->date) {
+            $item->addChild('pubDate', $post->date->dateTimeObject->format(DATE_RSS));
+        }
     }
 
     protected function addInitialChannelItems(): void

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -14,12 +14,9 @@ use Hyde\Framework\Hyde;
 class RssFeedService
 {
     public SimpleXMLElement $feed;
-    protected float $time_start;
 
     public function __construct()
     {
-        $this->time_start = microtime(true);
-
         $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" />');
         $this->feed->addChild('channel');
 
@@ -37,8 +34,6 @@ class RssFeedService
 
     public function getXML(): string
     {
-        $this->feed->channel->generator->addAttribute('hyde:processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2), 'hyde');
-
         return $this->feed->asXML();
     }
 

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -2,11 +2,63 @@
 
 namespace Hyde\Framework\Services;
 
+use SimpleXMLElement;
+use Hyde\Framework\Hyde;
+
 /**
  * @see \Tests\Feature\Services\RssFeedServiceTest
  */
 class RssFeedService
 {
+    public SimpleXMLElement $feed;
+    protected float $time_start;
 
+    public function __construct()
+    {
+        $this->time_start = microtime(true);
+
+        $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" />');
+        $this->feed->addAttribute('generator', 'HydePHP '.Hyde::version());
+        $this->feed->addChild('channel');
+
+        $this->addInitialChannelItems();
+    }
+
+    public function generate(): self
+    {
+        // TODO: Implement generate() method.
+
+        return $this;
+    }
+
+    public function getXML(): string
+    {
+        $this->feed->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2));
+
+        return $this->feed->asXML();
+    }
+
+    protected function addInitialChannelItems(): void
+    {
+        $this->feed->channel->addChild('title', $this->getTitle());
+        $this->feed->channel->addChild('link', $this->getLink());
+        $this->feed->channel->addChild('description', $this->getDescription());
+    }
+
+    protected function getTitle(): string
+    {
+        return config('hyde.name', 'HydePHP');
+    }
+
+    protected function getLink(): string
+    {
+        return config('hyde.site_url') ?? 'http://localhost';
+    }
+
+    protected function getDescription(): string
+    {
+        return config('hyde.rssDescription',
+            $this->getTitle() . ' RSS Feed');
+    }
 }
 

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -21,7 +21,6 @@ class RssFeedService
         $this->time_start = microtime(true);
 
         $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" />');
-        $this->feed->addAttribute('generator', 'HydePHP '.Hyde::version());
         $this->feed->addChild('channel');
 
         $this->addInitialChannelItems();
@@ -38,7 +37,7 @@ class RssFeedService
 
     public function getXML(): string
     {
-        $this->feed->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2));
+        $this->feed->channel->generator->addAttribute('hyde:processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2), 'hyde');
 
         return $this->feed->asXML();
     }
@@ -69,6 +68,15 @@ class RssFeedService
         $this->feed->channel->addChild('title', $this->getTitle());
         $this->feed->channel->addChild('link', $this->getLink());
         $this->feed->channel->addChild('description', $this->getDescription());
+
+        $this->addAdditionalChannelData();
+    }
+
+    protected function addAdditionalChannelData(): void
+    {
+        $this->feed->channel->addChild('language', config('hyde.language', 'en'));
+        $this->feed->channel->addChild('generator', 'HydePHP '.Hyde::version());
+        $this->feed->channel->addChild('lastBuildDate', date(DATE_RSS));
     }
 
     protected function getTitle(): string

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -17,7 +17,8 @@ class RssFeedService
 
     public function __construct()
     {
-        $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" />');
+        $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" />');
         $this->feed->addChild('channel');
 
         $this->addInitialChannelItems();
@@ -73,8 +74,6 @@ class RssFeedService
         $atomLink->addAttribute('href', $this->getLink() . '/rss.xml');
         $atomLink->addAttribute('rel', 'self');
         $atomLink->addAttribute('type', 'application/rss+xml');
-
-
 
         $this->addAdditionalChannelData();
     }

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -47,18 +47,29 @@ class RssFeedService
 
     protected function getTitle(): string
     {
-        return config('hyde.name', 'HydePHP');
+        return $this->xmlEscape(
+            config('hyde.name', 'HydePHP')
+        );
     }
 
     protected function getLink(): string
     {
-        return config('hyde.site_url') ?? 'http://localhost';
+        return $this->xmlEscape(
+            config('hyde.site_url') ?? 'http://localhost'
+        );
     }
 
     protected function getDescription(): string
     {
-        return config('hyde.rssDescription',
-            $this->getTitle() . ' RSS Feed');
+        return $this->xmlEscape(
+            config('hyde.rssDescription',
+                $this->getTitle() . ' RSS Feed')
+        );
+    }
+
+    protected function xmlEscape(string $string): string
+    {
+        return htmlspecialchars($string, ENT_XML1 | ENT_COMPAT, 'UTF-8');
     }
 }
 

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -62,6 +62,14 @@ class RssFeedService
         if (isset($post->category)) {
             $item->addChild('category', $post->category);
         }
+
+        // Only support local images, as remote images would take extra time to make HTTP requests to get length
+        if (isset($post->image) && isset($post->image->path)) {
+            $image = $item->addChild('enclosure');
+            $image->addAttribute('url' , Hyde::uriPath(str_replace('_media', 'media', $post->image->path)));
+            $image->addAttribute('type' , str_ends_with($post->image->path, '.png') ? 'image/png' : 'image/jpeg');
+            $image->addAttribute('length' , filesize(Hyde::path($post->image->path)));
+        }
     }
 
     protected function addInitialChannelItems(): void

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -57,6 +57,10 @@ class RssFeedService
         if (isset($post->author)) {
             $item->addChild('dc:creator', $post->author->getName(), 'http://purl.org/dc/elements/1.1/');
         }
+
+        if (isset($post->category)) {
+            $item->addChild('category', $post->category);
+        }
     }
 
     protected function addInitialChannelItems(): void

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -17,7 +17,7 @@ class RssFeedService
 
     public function __construct()
     {
-        $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" />');
+        $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" />');
         $this->feed->addChild('channel');
 
         $this->addInitialChannelItems();

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -47,6 +47,7 @@ class RssFeedService
         $item = $this->feed->channel->addChild('item');
         $item->addChild('title', $post->findTitleForDocument());
         $item->addChild('link', $post->getCanonicalLink());
+        $item->addChild('guid', $post->getCanonicalLink());
         $item->addChild('description', $post->getPostDescription());
 
         $this->addAdditionalItemData($item, $post);

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -80,7 +80,7 @@ class RssFeedService
         $this->feed->channel->addChild('description', $this->getDescription());
 
         $atomLink = $this->feed->channel->addChild('atom:link', namespace: 'http://www.w3.org/2005/Atom');
-        $atomLink->addAttribute('href', $this->getLink() . '/rss.xml');
+        $atomLink->addAttribute('href', $this->getLink() . '/' . static::getDefaultOutputFilename());
         $atomLink->addAttribute('rel', 'self');
         $atomLink->addAttribute('type', 'application/rss+xml');
 
@@ -119,6 +119,11 @@ class RssFeedService
     protected function xmlEscape(string $string): string
     {
         return htmlspecialchars($string, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+    }
+
+    public static function getDefaultOutputFilename(): string
+    {
+        return config('hyde.rssFilename', 'feed.rss');
     }
 }
 

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -8,6 +8,8 @@ use Hyde\Framework\Hyde;
 
 /**
  * @see \Tests\Feature\Services\RssFeedServiceTest
+ *
+ * @see https://validator.w3.org/feed/docs/rss2.html
  */
 class RssFeedService
 {

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -125,6 +125,11 @@ class RssFeedService
         return config('hyde.rssFilename', 'feed.rss');
     }
 
+    public static function generateFeed(): string
+    {
+        return (new static)->generate()->getXML();
+    }
+
     public static function canGenerateFeed(): bool
     {
         return (Hyde::uriPath() !== false) && config('hyde.generateRssFeed', true);

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -124,4 +124,9 @@ class RssFeedService
     {
         return config('hyde.rssFilename', 'feed.rss');
     }
+
+    public static function canGenerateFeed(): bool
+    {
+        return (Hyde::uriPath() !== false) && config('hyde.generateRssFeed', true);
+    }
 }

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -55,11 +55,13 @@ class RssFeedService
 
     protected function addAdditionalItemData(SimpleXMLElement $item, MarkdownPost $post): void
     {
-        if ($post->date) {
+        if (isset($post->date)) {
             $item->addChild('pubDate', $post->date->dateTimeObject->format(DATE_RSS));
         }
 
-        $item->addChild('author', $post->author->getName());
+        if (isset($post->author)) {
+            $item->addChild('author', $post->author->getName());
+        }
     }
 
     protected function addInitialChannelItems(): void

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -58,6 +58,8 @@ class RssFeedService
         if ($post->date) {
             $item->addChild('pubDate', $post->date->dateTimeObject->format(DATE_RSS));
         }
+
+        $item->addChild('author', $post->author->getName());
     }
 
     protected function addInitialChannelItems(): void

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -26,6 +26,7 @@ class RssFeedService
 
     public function generate(): self
     {
+        /** @var MarkdownPost $post */
         foreach (Hyde::getLatestPosts() as $post) {
             $this->addItem($post);
         }

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -2,6 +2,7 @@
 
 namespace Hyde\Framework\Services;
 
+use Hyde\Framework\Models\MarkdownPost;
 use SimpleXMLElement;
 use Hyde\Framework\Hyde;
 
@@ -26,7 +27,9 @@ class RssFeedService
 
     public function generate(): self
     {
-        // TODO: Implement generate() method.
+        foreach (Hyde::getLatestPosts() as $post) {
+            $this->addItem($post);
+        }
 
         return $this;
     }
@@ -36,6 +39,14 @@ class RssFeedService
         $this->feed->addAttribute('processing_time_ms', (string) round((microtime(true) - $this->time_start) * 1000, 2));
 
         return $this->feed->asXML();
+    }
+
+    protected function addItem(MarkdownPost $post): void
+    {
+        $item = $this->feed->channel->addChild('item');
+        $item->addChild('title', $post->findTitleForDocument());
+        $item->addChild('link', $post->getCanonicalLink());
+        $item->addChild('description', $post->getPostDescription());
     }
 
     protected function addInitialChannelItems(): void

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -17,7 +17,7 @@ class RssFeedService
 
     public function __construct()
     {
-        $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" />');
+        $this->feed = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" />');
         $this->feed->addChild('channel');
 
         $this->addInitialChannelItems();
@@ -64,6 +64,13 @@ class RssFeedService
         $this->feed->channel->addChild('title', $this->getTitle());
         $this->feed->channel->addChild('link', $this->getLink());
         $this->feed->channel->addChild('description', $this->getDescription());
+
+        $atomLink = $this->feed->channel->addChild('atom:link', namespace: 'http://www.w3.org/2005/Atom');
+        $atomLink->addAttribute('href', $this->getLink() . '/rss.xml');
+        $atomLink->addAttribute('rel', 'self');
+        $atomLink->addAttribute('type', 'application/rss+xml');
+
+
 
         $this->addAdditionalChannelData();
     }

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -2,8 +2,11 @@
 
 namespace Hyde\Framework\Services;
 
+/**
+ * @see \Tests\Feature\Services\RssFeedServiceTest
+ */
 class RssFeedService
 {
-	
+
 }
 

--- a/src/Services/RssFeedService.php
+++ b/src/Services/RssFeedService.php
@@ -60,7 +60,7 @@ class RssFeedService
         }
 
         if (isset($post->author)) {
-            $item->addChild('author', $post->author->getName());
+            $item->addChild('dc:creator', $post->author->getName(), 'http://purl.org/dc/elements/1.1/');
         }
     }
 

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -112,10 +112,37 @@ class BuildStaticSiteCommandTest extends TestCase
 
         unlinkIfExists(Hyde::path('_site/sitemap.xml'));
         $this->artisan('build')
-            ->expectsOutput('Generating sitemap.xml')
+            ->expectsOutput('Generating sitemap...')
             ->assertExitCode(0);
 
         $this->assertFileExists(Hyde::path('_site/sitemap.xml'));
+        unlink(Hyde::path('_site/sitemap.xml'));
+    }
+
+    public function test_rss_feed_is_not_generated_when_conditions_are_not_met()
+    {
+        config(['hyde.site_url' => '']);
+        config(['hyde.generateRssFeed' => false]);
+
+        unlinkIfExists(Hyde::path('_site/feed.rss'));
+        $this->artisan('build')
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist(Hyde::path('_site/feed.rss'));
+    }
+
+    public function test_rss_feed_is_generated_when_conditions_are_met()
+    {
+        config(['hyde.site_url' => 'https://example.com']);
+        config(['hyde.generateRssFeed' => true]);
+
+        unlinkIfExists(Hyde::path('_site/feed.rss'));
+        $this->artisan('build')
+            ->expectsOutput('Generating RSS feed...')
+            ->assertExitCode(0);
+
+        $this->assertFileExists(Hyde::path('_site/feed.rss'));
+        unlink(Hyde::path('_site/feed.rss'));
     }
 
     /**

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -145,6 +145,24 @@ class BuildStaticSiteCommandTest extends TestCase
         unlink(Hyde::path('_site/feed.rss'));
     }
 
+    public function test_rss_filename_can_be_changed()
+    {
+        config(['hyde.site_url' => 'https://example.com']);
+        config(['hyde.generateRssFeed' => true]);
+        config(['hyde.rssFilename' => 'blog.xml']);
+
+        unlinkIfExists(Hyde::path('_site/feed.rss'));
+        unlinkIfExists(Hyde::path('_site/blog.xml'));
+
+        $this->artisan('build')
+            ->expectsOutput('Generating RSS feed...')
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist(Hyde::path('_site/feed.rss'));
+        $this->assertFileExists(Hyde::path('_site/blog.xml'));
+        unlink(Hyde::path('_site/blog.xml'));
+    }
+
     /**
      * Added for code coverage, deprecated as the pretty flag is deprecated.
      *

--- a/tests/Feature/Services/RssFeedServiceTest.php
+++ b/tests/Feature/Services/RssFeedServiceTest.php
@@ -129,6 +129,11 @@ class RssFeedServiceTest extends TestCase
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', ($service->getXML()));
     }
 
+    // Test generateFeed helper returns XML string
+    public function test_generateFeed_helper_returns_XML_string()
+    {
+        $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', (RssFeedService::generateFeed()));
+    }
 
     public function test_can_generate_sitemap_helper_returns_true_if_hyde_has_base_url()
     {

--- a/tests/Feature/Services/RssFeedServiceTest.php
+++ b/tests/Feature/Services/RssFeedServiceTest.php
@@ -57,7 +57,7 @@ class RssFeedServiceTest extends TestCase
         $service = new RssFeedService();
         $this->assertObjectHasAttribute('link', $service->feed->channel);
         $this->assertEquals('https://example.com', $service->feed->channel->link);
-        $this->assertEquals('https://example.com/rss.xml',
+        $this->assertEquals('https://example.com/feed.rss',
             $service->feed->channel->children('atom', true)->link->attributes()->href);
 
         $this->assertObjectHasAttribute('language', $service->feed->channel);

--- a/tests/Feature/Services/RssFeedServiceTest.php
+++ b/tests/Feature/Services/RssFeedServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Services\SitemapServiceTest;
+namespace Tests\Feature\Services;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\RssFeedService;

--- a/tests/Feature/Services/RssFeedServiceTest.php
+++ b/tests/Feature/Services/RssFeedServiceTest.php
@@ -128,4 +128,24 @@ class RssFeedServiceTest extends TestCase
         $service = new RssFeedService();
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', ($service->getXML()));
     }
+
+
+    public function test_can_generate_sitemap_helper_returns_true_if_hyde_has_base_url()
+    {
+        config(['hyde.site_url' => 'foo']);
+        $this->assertTrue(RssFeedService::canGenerateFeed());
+    }
+
+    public function test_can_generate_sitemap_helper_returns_false_if_hyde_does_not_have_base_url()
+    {
+        config(['hyde.site_url' => '']);
+        $this->assertFalse(RssFeedService::canGenerateFeed());
+    }
+
+    public function test_can_generate_sitemap_helper_returns_false_if_sitemaps_are_disabled_in_config()
+    {
+        config(['hyde.site_url' => 'foo']);
+        config(['hyde.generateRssFeed' => false]);
+        $this->assertFalse(RssFeedService::canGenerateFeed());
+    }
 }

--- a/tests/Feature/Services/RssFeedServiceTest.php
+++ b/tests/Feature/Services/RssFeedServiceTest.php
@@ -11,5 +11,121 @@ use Tests\TestCase;
  */
 class RssFeedServiceTest extends TestCase
 {
-	
+	// Test service instantiates the XML element
+	public function test_service_instantiates_xml_element()
+    {
+        $service = new RssFeedService();
+        $this->assertInstanceOf('SimpleXMLElement', $service->feed);
+    }
+
+	// Test XML root element is set to RSS 2.0
+	public function test_xml_root_element_is_set_to_rss_2_0()
+	{
+		$service = new RssFeedService();
+		$this->assertEquals('rss', $service->feed->getName());
+		$this->assertEquals('2.0', $service->feed->attributes()->version);
+	}
+
+	// Test XML element has channel element
+	public function test_xml_element_has_channel_element()
+	{
+		$service = new RssFeedService();
+		$this->assertObjectHasAttribute('channel', $service->feed);
+	}
+
+	// Test XML channel element has required elements
+	public function test_xml_channel_element_has_required_elements()
+	{
+        config(['hyde.name' => 'Test Blog']);
+        config(['hyde.site_url' => 'https://example.com']);
+
+        $service = new RssFeedService();
+		$this->assertObjectHasAttribute('title', $service->feed->channel);
+		$this->assertObjectHasAttribute('link', $service->feed->channel);
+		$this->assertObjectHasAttribute('description', $service->feed->channel);
+
+        $this->assertEquals('Test Blog', $service->feed->channel->title);
+        $this->assertEquals('https://example.com', $service->feed->channel->link);
+        $this->assertEquals('Test Blog RSS Feed', $service->feed->channel->description);
+	}
+
+    // Test XML channel element has additional elements
+    public function test_xml_channel_element_has_additional_elements()
+    {
+        config(['hyde.site_url' => 'https://example.com']);
+
+        $service = new RssFeedService();
+        $this->assertObjectHasAttribute('link', $service->feed->channel);
+        $this->assertEquals('https://example.com', $service->feed->channel->link);
+        $this->assertEquals('https://example.com/rss.xml',
+            $service->feed->channel->children('atom', true)->link->attributes()->href);
+
+        $this->assertObjectHasAttribute('language', $service->feed->channel);
+        $this->assertObjectHasAttribute('generator', $service->feed->channel);
+        $this->assertObjectHasAttribute('lastBuildDate', $service->feed->channel);
+    }
+
+    // Test XML channel data can be customized
+    public function test_xml_channel_data_can_be_customized()
+    {
+        config(['hyde.name' => 'Foo']);
+        config(['hyde.site_url' => 'https://blog.foo.com/bar']);
+        config(['hyde.rssDescription' => 'Foo is a web log about stuff']);
+
+        $service = new RssFeedService();
+        $this->assertEquals('Foo', $service->feed->channel->title);
+        $this->assertEquals('https://blog.foo.com/bar', $service->feed->channel->link);
+        $this->assertEquals('Foo is a web log about stuff', $service->feed->channel->description);
+    }
+
+    // Test Markdown blog posts are added to RSS feed through autodiscovery
+    public function test_markdown_blog_posts_are_added_to_rss_feed_through_autodiscovery()
+    {
+        file_put_contents(Hyde::path('_posts/rss.md'), <<<'MD'
+            ---
+            title: RSS
+            author: Hyde
+            date: "2022-05-19 10:15:30"
+            description: RSS description
+            category: test
+            image: rss-test.jpg
+            ---
+            
+            # RSS Post
+            
+            Foo bar
+            MD
+        );
+
+        config(['hyde.site_url' => 'https://example.com']);
+
+        file_put_contents(Hyde::path('rss-test.jpg'), 'statData'); // 8 bytes to test stat gets file length
+
+        $service = new RssFeedService();
+        $service->generate();
+		$this->assertCount(1, $service->feed->channel->item);
+
+        $item = $service->feed->channel->item[0];
+        $this->assertEquals('RSS', $item->title);
+        $this->assertEquals('RSS description', $item->description);
+        $this->assertEquals('https://example.com/posts/rss.html', $item->link);
+        $this->assertEquals(date(DATE_RSS, strtotime('2022-05-19T10:15:30+00:00')), $item->pubDate);
+        $this->assertEquals('Hyde', $item->children('dc', true)->creator);
+        $this->assertEquals('test', $item->category);
+
+        $this->assertObjectHasAttribute('enclosure', $item);
+        $this->assertEquals('https://example.com/rss-test.jpg', $item->enclosure->attributes()->url);
+        $this->assertEquals('image/jpeg', $item->enclosure->attributes()->type);
+        $this->assertEquals('8', $item->enclosure->attributes()->length);
+
+        unlink(Hyde::path('_posts/rss.md'));
+        unlink(Hyde::path('rss-test.jpg'));
+    }
+
+    // Test getXML method returns XML string
+    public function test_getXML_method_returns_XML_string()
+    {
+        $service = new RssFeedService();
+        $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>', ($service->getXML()));
+    }
 }

--- a/tests/Feature/Services/SitemapServiceTest.php
+++ b/tests/Feature/Services/SitemapServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Services\SitemapServiceTest;
+namespace Tests\Feature\Services;
 
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Services\SitemapService;

--- a/tests/Feature/Services/SitemapServiceTest/RssFeedServiceTest.php
+++ b/tests/Feature/Services/SitemapServiceTest/RssFeedServiceTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Feature\Services\SitemapServiceTest;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Services\RssFeedService;
+use Tests\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Services\RssFeedService
+ */
+class RssFeedServiceTest extends TestCase
+{
+	
+}


### PR DESCRIPTION
### RSS feed generation

When enabled, an RSS feed with your Markdown blog posts will be generated when you compile your static site.
Note that this requires that a site_url is set!

```php // config/hyde.php
'generateRssFeed' => true, // Default is true
```

You can customize the output filename using the following:

```php // config/hyde.php
'rssFilename' => 'feed.xml', // Default is feed.rss
```

You can set the RSS channel description using the following:

```php // config/hyde.php
'rssDescription' => 'A collection of articles and tutorials from my blog', // Example
```

If an rssDescription is not set one is created by appending "RSS Feed" to your site name.

