### PR TITLE
Fix #450: Add custom exceptions

### DIFF
--- a/src/Actions/CreatesNewMarkdownPostFile.php
+++ b/src/Actions/CreatesNewMarkdownPostFile.php
@@ -2,7 +2,7 @@
 
 namespace Hyde\Framework\Actions;
 
-use Exception;
+use Hyde\Framework\Exceptions\FileConflictException;
 use Hyde\Framework\Hyde;
 use Illuminate\Support\Str;
 
@@ -95,14 +95,14 @@ class CreatesNewMarkdownPostFile
      * @param  bool  $force  Should the file be created even if a file with the same path already exists?
      * @return string|false Returns the path to the file if successful, or false if the file could not be saved.
      *
-     * @throws Exception if a file with the same slug already exists and the force flag is not set.
+     * @throws FileConflictException if a file with the same slug already exists and the force flag is not set.
      */
     public function save(bool $force = false): string|false
     {
         $path = Hyde::path("_posts/$this->slug.md");
 
         if ($force !== true && file_exists($path)) {
-            throw new Exception("File at $path already exists! ", 409);
+            throw new FileConflictException($path);
         }
 
         $arrayWithoutSlug = ((array) $this);

--- a/src/Actions/CreatesNewPageSourceFile.php
+++ b/src/Actions/CreatesNewPageSourceFile.php
@@ -2,7 +2,6 @@
 
 namespace Hyde\Framework\Actions;
 
-use Exception;
 use Hyde\Framework\Exceptions\FileConflictException;
 use Hyde\Framework\Exceptions\UnsupportedPageTypeException;
 use Hyde\Framework\Hyde;
@@ -18,32 +17,10 @@ use Illuminate\Support\Str;
  */
 class CreatesNewPageSourceFile
 {
-    /**
-     * The Page title.
-     *
-     * @var string
-     */
     public string $title;
-
-    /**
-     * The Page slug.
-     */
     public string $slug;
+    public string $outputPath;
 
-    /**
-     * The file path.
-     */
-    public string $path;
-
-    /**
-     * Construct the class.
-     *
-     * @param  string  $title  - The page title, will be used to generate the slug
-     * @param  string  $type  - The page type, FQDN of the page class
-     * @param  bool  $force  - Overwrite any existing files?
-     *
-     * @throws Exception if the page type is not supported or the file already exists
-     */
     public function __construct(string $title, string $type = MarkdownPage::class, public bool $force = false)
     {
         $this->title = $title;
@@ -52,11 +29,7 @@ class CreatesNewPageSourceFile
         $this->createPage($type);
     }
 
-    /**
-     * Check if the file can be saved.
-     *
-     * @throws FileConflictException if the file already exists and cannot be overwritten
-     */
+
     public function canSaveFile(string $path): void
     {
         if (file_exists($path) && ! $this->force) {
@@ -64,13 +37,6 @@ class CreatesNewPageSourceFile
         }
     }
 
-    /**
-     * Create the page.
-     *
-     * @param  string  $type  FQDN of the page class
-     *
-     * @throws UnsupportedPageTypeException if the page type is not supported
-     */
     public function createPage(string $type): int|false
     {
         if ($type === MarkdownPage::class) {
@@ -87,36 +53,26 @@ class CreatesNewPageSourceFile
         throw new UnsupportedPageTypeException('The page type must be either "markdown", "blade", or "documentation"');
     }
 
-    /**
-     * Create the Markdown file.
-     *
-     * @throws FileConflictException if the file cannot be saved.
-     */
     public function createMarkdownFile(): int|false
     {
-        $this->path = Hyde::path("_pages/$this->slug.md");
+        $this->outputPath = Hyde::path("_pages/$this->slug.md");
 
-        $this->canSaveFile($this->path);
+        $this->canSaveFile($this->outputPath);
 
         return file_put_contents(
-            $this->path,
+            $this->outputPath,
             "---\ntitle: $this->title\n---\n\n# $this->title\n"
         );
     }
 
-    /**
-     * Create the Blade file.
-     *
-     * @throws FileConflictException if the file cannot be saved.
-     */
     public function createBladeFile(): int|false
     {
-        $this->path = Hyde::path("_pages/$this->slug.blade.php");
+        $this->outputPath = Hyde::path("_pages/$this->slug.blade.php");
 
-        $this->canSaveFile($this->path);
+        $this->canSaveFile($this->outputPath);
 
         return file_put_contents(
-            $this->path,
+            $this->outputPath,
             <<<EOF
 @extends('hyde::layouts.app')
 @section('content')
@@ -132,19 +88,14 @@ EOF
         );
     }
 
-    /**
-     * Create the Documentation file.
-     *
-     * @throws FileConflictException if the file cannot be saved.
-     */
     public function createDocumentationFile(): int|false
     {
-        $this->path = Hyde::path("_docs/$this->slug.md");
+        $this->outputPath = Hyde::path("_docs/$this->slug.md");
 
-        $this->canSaveFile($this->path);
+        $this->canSaveFile($this->outputPath);
 
         return file_put_contents(
-            $this->path,
+            $this->outputPath,
             "# $this->title\n"
         );
     }

--- a/src/Actions/CreatesNewPageSourceFile.php
+++ b/src/Actions/CreatesNewPageSourceFile.php
@@ -3,6 +3,7 @@
 namespace Hyde\Framework\Actions;
 
 use Exception;
+use Hyde\Framework\Exceptions\FileConflictException;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
@@ -53,12 +54,12 @@ class CreatesNewPageSourceFile
     /**
      * Check if the file can be saved.
      *
-     * @throws Exception if the file already exists and cannot be overwritten
+     * @throws FileConflictException if the file already exists and cannot be overwritten
      */
     public function canSaveFile(string $path): void
     {
         if (file_exists($path) && ! $this->force) {
-            throw new Exception("File $path already exists!", 409);
+            throw new FileConflictException($path);
         }
     }
 
@@ -88,7 +89,7 @@ class CreatesNewPageSourceFile
     /**
      * Create the Markdown file.
      *
-     * @throws Exception if the file cannot be saved.
+     * @throws FileConflictException if the file cannot be saved.
      */
     public function createMarkdownFile(): int|false
     {
@@ -105,7 +106,7 @@ class CreatesNewPageSourceFile
     /**
      * Create the Blade file.
      *
-     * @throws Exception if the file cannot be saved.
+     * @throws FileConflictException if the file cannot be saved.
      */
     public function createBladeFile(): int|false
     {
@@ -133,7 +134,7 @@ EOF
     /**
      * Create the Documentation file.
      *
-     * @throws Exception if the file cannot be saved.
+     * @throws FileConflictException if the file cannot be saved.
      */
     public function createDocumentationFile(): int|false
     {

--- a/src/Actions/CreatesNewPageSourceFile.php
+++ b/src/Actions/CreatesNewPageSourceFile.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Actions;
 
 use Exception;
 use Hyde\Framework\Exceptions\FileConflictException;
+use Hyde\Framework\Exceptions\UnsupportedPageTypeException;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
@@ -68,7 +69,7 @@ class CreatesNewPageSourceFile
      *
      * @param  string  $type  FQDN of the page class
      *
-     * @throws Exception if the page type is not supported
+     * @throws UnsupportedPageTypeException if the page type is not supported
      */
     public function createPage(string $type): int|false
     {
@@ -83,7 +84,7 @@ class CreatesNewPageSourceFile
             return $this->createDocumentationFile();
         }
 
-        throw new Exception('The page type must be either "markdown", "blade", or "documentation"');
+        throw new UnsupportedPageTypeException('The page type must be either "markdown", "blade", or "documentation"');
     }
 
     /**

--- a/src/Concerns/HasDateString.php
+++ b/src/Concerns/HasDateString.php
@@ -14,7 +14,7 @@ trait HasDateString
     public ?DateString $date = null;
 
     /**
-     * @throws \Exception
+     * @throws \Hyde\Framework\Exceptions\CouldNotParseDateStringException
      */
     public function constructDateString(): void
     {

--- a/src/Concerns/ValidatesExistence.php
+++ b/src/Concerns/ValidatesExistence.php
@@ -2,18 +2,20 @@
 
 namespace Hyde\Framework\Concerns;
 
-use Exception;
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Hyde;
 
 /**
  * Validate the existence of a Page model's source file.
+ *
+ * @see \Tests\Unit\ValidatesExistenceTest
  */
 trait ValidatesExistence
 {
     /**
      * Check if a supplied source file exists or throw an exception.
      *
-     * @throws Exception If the file does not exist.
+     * @throws FileNotFoundException If the file does not exist.
      */
     public function validateExistence(string $model, string $slug): void
     {
@@ -22,7 +24,7 @@ trait ValidatesExistence
             $slug.$model::$fileExtension;
 
         if (! file_exists(Hyde::path($filepath))) {
-            throw new Exception("File $filepath not found.", 404);
+            throw new FileNotFoundException("File $filepath not found.", 404);
         }
     }
 }

--- a/src/Concerns/ValidatesExistence.php
+++ b/src/Concerns/ValidatesExistence.php
@@ -24,7 +24,7 @@ trait ValidatesExistence
             $slug.$model::$fileExtension;
 
         if (! file_exists(Hyde::path($filepath))) {
-            throw new FileNotFoundException("File $filepath not found.", 404);
+            throw new FileNotFoundException($filepath);
         }
     }
 }

--- a/src/Exceptions/CouldNotParseDateStringException.php
+++ b/src/Exceptions/CouldNotParseDateStringException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyde\Framework\Exceptions;
+
+use Exception;
+
+class CouldNotParseDateStringException extends Exception
+{
+    //
+}

--- a/src/Exceptions/FileConflictException.php
+++ b/src/Exceptions/FileConflictException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Hyde\Framework\Exceptions;
+
+use Exception;
+
+class FileConflictException extends Exception
+{
+    protected $message = 'A file already exists at this path.';
+	protected $code = 409;
+
+	public function __construct(?string $path = null)
+	{
+		$this->message = $path ? "File already exists: {$path}" : $this->message;
+	}
+}

--- a/src/Exceptions/FileNotFoundException.php
+++ b/src/Exceptions/FileNotFoundException.php
@@ -6,5 +6,11 @@ use Exception;
 
 class FileNotFoundException extends Exception
 {
-    //
+    protected $message = 'File not found.';
+	protected $code = 404;
+
+    public function __construct(?string $path = null)
+    {
+        $this->message = $path ? "File not found: {$path}" : $this->message;
+    }
 }

--- a/src/Exceptions/FileNotFoundException.php
+++ b/src/Exceptions/FileNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyde\Framework\Exceptions;
+
+use Exception;
+
+class FileNotFoundException extends Exception
+{
+    //
+}

--- a/src/Exceptions/UnsupportedPageTypeException.php
+++ b/src/Exceptions/UnsupportedPageTypeException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Hyde\Framework\Exceptions;
+
+use Exception;
+
+class UnsupportedPageTypeException extends Exception
+{
+    protected $message = 'The page type is not supported.';
+	protected $code = 400;
+
+    public function __construct(?string $page = null)
+    {
+        $this->message = $page ? "The page type is not supported: {$page}" : $this->message;
+    }
+}

--- a/src/Hyde.php
+++ b/src/Hyde.php
@@ -53,9 +53,6 @@ class Hyde
         return Str::title(str_replace('-', ' ', ($slug)));
     }
 
-    /**
-     * @throws \Exception
-     */
     public static function getLatestPosts(): Collection
     {
         $collection = new Collection();

--- a/src/Models/DateString.php
+++ b/src/Models/DateString.php
@@ -3,9 +3,11 @@
 namespace Hyde\Framework\Models;
 
 use DateTime;
+use Hyde\Framework\Exceptions\CouldNotParseDateStringException;
 
 /**
  * Parse a date string and create normalized formats.
+ * @see \Tests\Unit\DateStringTest
  */
 class DateString
 {
@@ -25,15 +27,18 @@ class DateString
     public string $short;
 
     /**
-     * @param  string  $string
-     *
-     * @throws \Exception
+     * @param string $string
+     * @throws \Hyde\Framework\Exceptions\CouldNotParseDateStringException 
      */
     public function __construct(string $string)
     {
         $this->string = $string;
 
-        $this->dateTimeObject = new DateTime($this->string);
+        try {
+            $this->dateTimeObject = new DateTime($this->string);
+        } catch (\Exception $e) {
+            throw new CouldNotParseDateStringException($e->getMessage());
+        }
 
         $this->datetime = $this->dateTimeObject->format('c');
         $this->sentence = $this->dateTimeObject->format('l M jS, Y, \a\t g:ia');

--- a/src/Models/MarkdownPost.php
+++ b/src/Models/MarkdownPost.php
@@ -22,7 +22,7 @@ class MarkdownPost extends MarkdownDocument
     public static string $parserClass = MarkdownPostParser::class;
 
     /**
-     * @throws \Exception
+     * @throws \Hyde\Framework\Exceptions\CouldNotParseDateStringException
      */
     public function __construct(array $matter, string $body, string $title = '', string $slug = '')
     {

--- a/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Actions;
 
 use Exception;
 use Hyde\Framework\Actions\CreatesNewPageSourceFile;
+use Hyde\Framework\Exceptions\FileConflictException;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
@@ -56,8 +57,8 @@ class CreatesNewPageSourceFileTest extends TestCase
         $path = Hyde::path('_pages/foo.md');
         file_put_contents($path, 'foo');
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage("File $path already exists!");
+        $this->expectException(FileConflictException::class);
+        $this->expectExceptionMessage("File already exists: $path");
         $this->expectExceptionCode(409);
 
         new CreatesNewPageSourceFile('foo');

--- a/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature\Actions;
 
-use Exception;
 use Hyde\Framework\Actions\CreatesNewPageSourceFile;
 use Hyde\Framework\Exceptions\FileConflictException;
+use Hyde\Framework\Exceptions\UnsupportedPageTypeException;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\BladePage;
 use Hyde\Framework\Models\DocumentationPage;
@@ -46,7 +46,7 @@ class CreatesNewPageSourceFileTest extends TestCase
 
     public function test_that_an_exception_is_thrown_for_invalid_page_type()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(UnsupportedPageTypeException::class);
         $this->expectExceptionMessage('The page type must be either "markdown", "blade", or "documentation"');
 
         (new CreatesNewPageSourceFile('682072b Test Page', 'invalid'));

--- a/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -132,12 +132,12 @@ class CreatesNewPageSourceFileTest extends TestCase
     {
         $this->assertEquals(
             Hyde::path('_pages/682072b-test-page.md'),
-            (new CreatesNewPageSourceFile('682072b Test Page'))->path
+            (new CreatesNewPageSourceFile('682072b Test Page'))->outputPath
         );
 
         $this->assertEquals(
             Hyde::path('_pages/682072b-test-page.blade.php'),
-            (new CreatesNewPageSourceFile('682072b Test Page', BladePage::class))->path
+            (new CreatesNewPageSourceFile('682072b Test Page', BladePage::class))->outputPath
         );
     }
 }

--- a/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
+++ b/tests/Feature/Actions/CreatesNewPageSourceFileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Actions;
 
 use Exception;
 use Hyde\Framework\Actions\CreatesNewPageSourceFile;

--- a/tests/Feature/Commands/HydeMakePageCommandTest.php
+++ b/tests/Feature/Commands/HydeMakePageCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Commands;
 
 use Exception;
+use Hyde\Framework\Exceptions\FileConflictException;
 use Hyde\Framework\Hyde;
 use Tests\TestCase;
 
@@ -102,8 +103,8 @@ class HydeMakePageCommandTest extends TestCase
     {
         file_put_contents($this->markdownPath, 'This should not be overwritten');
 
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage("File $this->markdownPath already exists!");
+        $this->expectException(FileConflictException::class);
+        $this->expectExceptionMessage("File already exists: $this->markdownPath");
         $this->expectExceptionCode(409);
         $this->artisan('make:page "8450de2 test page"')->assertExitCode(409);
 

--- a/tests/Unit/DateStringTest.php
+++ b/tests/Unit/DateStringTest.php
@@ -3,9 +3,13 @@
 namespace Tests\Unit;
 
 use DateTime;
+use Hyde\Framework\Exceptions\CouldNotParseDateStringException;
 use Hyde\Framework\Models\DateString;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Hyde\Framework\Models\DateString
+ */
 class DateStringTest extends TestCase
 {
     // Test it can parse a date string
@@ -41,5 +45,12 @@ class DateStringTest extends TestCase
     {
         $dateString = new DateString('2020-01-01 UTC');
         $this->assertEquals('Jan 1st, 2020', $dateString->short);
+    }
+
+    // Test it handles invalid date strings
+    public function test_it_handles_invalid_date_strings()
+    {
+        $this->expectException(CouldNotParseDateStringException::class);
+        new DateString('foo bar');
     }
 }

--- a/tests/Unit/ValidatesExistenceTest.php
+++ b/tests/Unit/ValidatesExistenceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Hyde\Framework\Concerns\ValidatesExistence;
+use Hyde\Framework\Exceptions\FileNotFoundException;
 use Hyde\Framework\Models\BladePage;
 use Tests\TestCase;
 
@@ -24,7 +25,7 @@ class ValidatesExistenceTest extends TestCase
 
 	public function test_validate_existence_throws_file_not_found_exception_if_file_does_not_exist()
 	{
-		$this->expectException(\Hyde\Framework\Exceptions\FileNotFoundException::class);
+		$this->expectException(FileNotFoundException::class);
 
 		$class = new class {
 			use ValidatesExistence;

--- a/tests/Unit/ValidatesExistenceTest.php
+++ b/tests/Unit/ValidatesExistenceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit;
+
+use Hyde\Framework\Concerns\ValidatesExistence;
+use Hyde\Framework\Models\BladePage;
+use Tests\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Concerns\ValidatesExistence
+ */
+class ValidatesExistenceTest extends TestCase
+{
+	public function test_validate_existence_does_nothing_if_file_exists()
+	{
+		$class = new class {
+			use ValidatesExistence;
+		};
+
+		$class->validateExistence(BladePage::class, 'index');
+
+		$this->assertTrue(true);
+	}
+
+	public function test_validate_existence_throws_file_not_found_exception_if_file_does_not_exist()
+	{
+		$this->expectException(\Hyde\Framework\Exceptions\FileNotFoundException::class);
+
+		$class = new class {
+			use ValidatesExistence;
+		};
+
+		$class->validateExistence(BladePage::class, 'not-found');
+	}
+}


### PR DESCRIPTION
One of the nice things with precompiled sites are that they "fail early". There are no runtime errors or surprises. If something goes wrong, you will know before you ship to production. However, it would be nice to have some custom exceptions that are more descriptive when and if an error occurs. This PR starts to fix that.