### PR TITLE
Create the backend search index generation for documentation pages

### DIFF
--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -5,6 +5,7 @@ namespace Hyde\Framework\Actions;
 use Hyde\Framework\Contracts\ActionContract;
 use Hyde\Framework\Hyde;
 use Hyde\Framework\Models\Parsers\DocumentationPageParser;
+use Hyde\Framework\Services\CollectionService;
 use Illuminate\Support\Collection;
 
 /**
@@ -54,7 +55,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
 
     public function getSourceFileSlugs(): array
     {
-        return [];
+        return CollectionService::getDocumentationPageList();
     }
 
     public function getObject(): object

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -34,13 +34,15 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
         $this->save();
     }
 
-    public function generate(): void
+    public function generate(): self
     {
         foreach ($this->getSourceFileSlugs() as $page) {
             $this->searchIndex->push(
                 $this->generatePageObject($page)
             );
         }
+
+        return $this;
     }
 
     public function generatePageObject(string $slug): object
@@ -68,8 +70,10 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
         return json_encode($this->getObject());
     }
 
-    public function save(): void
+    public function save(): self
     {
         file_put_contents(Hyde::path(static::$filePath), $this->getJson());
+        
+        return $this;
     }
 }

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -116,12 +116,11 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
 
     public function getDestinationForSlug(string $slug): string
     {
-        if ($slug === 'index') {
+        if ($slug === 'index' && config('hyde.pretty_urls', false)) {
             $slug = '';
         }
 
         return (config('hyde.pretty_urls', false) === true)
-            ? $slug
-            : $slug.'.html';
+            ? $slug : $slug.'.html';
     }
 }

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -104,6 +104,9 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
      */
     public function getSearchContentForDocument(DocumentationPage $document): string
     {
+        // This is compiles the Markdown body into HTML, and then strips out all
+        // HTML tags to get a plain text version of the body. This takes a long
+        // site, but is the simplest implementation I've found so far.
         return preg_replace('/<(.|\n)*?>/', ' ', Str::markdown($document->body));
     }
 }

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -55,6 +55,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
             'slug' => $page->slug,
             'title' => trim($page->findTitleForDocument()),
             'content' => $this->getSearchContentForDocument($page),
+            'destination' => $this->getDestinationForSlug($page->slug),
         ];
     }
 
@@ -108,5 +109,16 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
         // HTML tags to get a plain text version of the body. This takes a long
         // site, but is the simplest implementation I've found so far.
         return preg_replace('/<(.|\n)*?>/', ' ', Str::markdown($document->body));
+    }
+
+    public function getDestinationForSlug(string $slug): string
+    {
+        if ($slug === 'index') {
+            $slug = '';
+        }
+
+        return (config('hyde.pretty_urls', false) === true)
+            ? $slug
+            : $slug.'.html';
     }
 }

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -51,7 +51,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
 
         return (object) [
             'slug' => $page->slug,
-            'title' => $page->findTitleForDocument(),
+            'title' => trim($page->findTitleForDocument()),
         ];
     }
 

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -4,9 +4,11 @@ namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Contracts\ActionContract;
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Models\Parsers\DocumentationPageParser;
 use Hyde\Framework\Services\CollectionService;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 /**
  * Generate a JSON file that can be used as a search index for documentation pages.
@@ -52,6 +54,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
         return (object) [
             'slug' => $page->slug,
             'title' => trim($page->findTitleForDocument()),
+            'content' => $this->getSearchContentForDocument($page),
         ];
     }
 
@@ -67,7 +70,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
 
     public function getJson(): string
     {
-        return json_encode($this->getObject());
+        return json_encode($this->getObject(), JSON_PRETTY_PRINT);
     }
 
     public function save(): self
@@ -75,5 +78,32 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
         file_put_contents(Hyde::path(static::$filePath), $this->getJson());
         
         return $this;
+    }
+
+    /**
+     * There are a few ways we could go about this. The goal is to allow the user
+     * to run a free-text search to find relevant documentation pages.
+     * 
+     * The easiest way to do this is by adding the Markdown body to the search index.
+     * But this is of course not ideal as it may take an incredible amount of space
+     * for large documentation sites. The Hyde docs weight around 80kb of JSON.
+     * 
+     * Another option is to assemble all the headings in a document and use that
+     * for the search basis. A truncated version of the body could also be included.
+     * 
+     * A third option which might be the most space efficient (besides from just
+     * adding titles, which doesn't offer much help to the user since it is just
+     * a filterable sidebar at that point), would be to search for keywords
+     * in the document. This would however add complexity as well as extra
+     * computing time. 
+     * 
+     * Benchmarks: (for official Hyde docs)
+     * 
+     * Returning $document->body as is: 500ms
+     * Returning $document->body as Str::markdown(): 920ms + 10ms for regex
+     */
+    public function getSearchContentForDocument(DocumentationPage $document): string
+    {
+        return preg_replace('/<(.|\n)*?>/', ' ', Str::markdown($document->body));
     }
 }

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -57,7 +57,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
         return (object) [
             'slug' => $page->slug,
             'title' => trim($page->findTitleForDocument()),
-            'content' => $this->getSearchContentForDocument($page),
+            'content' => trim($this->getSearchContentForDocument($page)),
             'destination' => $this->getDestinationForSlug($page->slug),
         ];
     }

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Collection;
 class GeneratesDocumentationSearchIndexFile implements ActionContract
 {
     public Collection $searchIndex;
-    public static string $filePath = '_site/docs/searchIndex.json';
+    public static string $filePath = '_site/docs/search.json';
 
     public static function run(): void
     {

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -12,6 +12,9 @@ use Illuminate\Support\Str;
 
 /**
  * Generate a JSON file that can be used as a search index for documentation pages.
+ * 
+ * @todo Convert into Service, and add more strategies, such as slug-only (no file parsing)
+ *        search which while dumber, would be much faster to compile and take way less space.
  *
  * @see \Tests\Feature\Actions\GeneratesDocumentationSearchIndexFileTest
  */

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Hyde\Framework\Actions;
+
+use Hyde\Framework\Contracts\ActionContract;
+
+/**
+ * Generate a JSON file that can be used as a search index for documentation pages.
+ *
+ * @see \Tests\Feature\Actions\GeneratesDocumentationSearchIndexFileTest
+ */
+class GeneratesDocumentationSearchIndexFile implements ActionContract
+{
+    public function execute()
+    {
+
+    }
+}

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -74,7 +74,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
 
     public function getJson(): string
     {
-        return json_encode($this->getObject(), JSON_PRETTY_PRINT);
+        return json_encode($this->getObject());
     }
 
     public function save(): self

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -3,6 +3,8 @@
 namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Contracts\ActionContract;
+use Hyde\Framework\Hyde;
+use Illuminate\Support\Collection;
 
 /**
  * Generate a JSON file that can be used as a search index for documentation pages.
@@ -11,8 +13,58 @@ use Hyde\Framework\Contracts\ActionContract;
  */
 class GeneratesDocumentationSearchIndexFile implements ActionContract
 {
-    public function execute()
-    {
+    public Collection $searchIndex;
+    public static string $filePath = '_site/docs/searchIndex.json';
 
+    public static function run(): void
+    {
+        (new static())->execute();
+    }
+
+    public function __construct()
+    {
+        $this->searchIndex = new Collection();
+    }
+
+    public function execute(): void
+    {
+        $this->generate();
+        $this->save();
+    }
+
+    public function generate(): void
+    {
+        foreach ($this->getSourceFileSlugs() as $page) {
+            $this->searchIndex->push(
+                $this->generatePageObject($page)
+            );
+        }
+    }
+
+    public function generatePageObject(string $slug): object
+    {
+        return (object) [
+            'slug' => $slug
+        ];
+    }
+
+    public function getSourceFileSlugs(): array
+    {
+        return [];
+    }
+
+    public function getObject(): object
+    {
+        return (object) $this->searchIndex;
+    }
+
+    public function getJson(): string
+    {
+        return json_encode($this->getObject());
+    }
+
+    public function save(): void
+    {
+        file_put_contents(Hyde::path(static::$filePath), $this->getJson());
     }
 }

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -51,7 +51,7 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
 
         return (object) [
             'slug' => $page->slug,
-            'title' => $page->title,
+            'title' => $page->findTitleForDocument(),
         ];
     }
 

--- a/src/Actions/GeneratesDocumentationSearchIndexFile.php
+++ b/src/Actions/GeneratesDocumentationSearchIndexFile.php
@@ -4,6 +4,7 @@ namespace Hyde\Framework\Actions;
 
 use Hyde\Framework\Contracts\ActionContract;
 use Hyde\Framework\Hyde;
+use Hyde\Framework\Models\Parsers\DocumentationPageParser;
 use Illuminate\Support\Collection;
 
 /**
@@ -43,8 +44,11 @@ class GeneratesDocumentationSearchIndexFile implements ActionContract
 
     public function generatePageObject(string $slug): object
     {
+        $page = (new DocumentationPageParser($slug))->get();
+
         return (object) [
-            'slug' => $slug
+            'slug' => $page->slug,
+            'title' => $page->title,
         ];
     }
 

--- a/src/Commands/HydeBuildRssFeedCommand.php
+++ b/src/Commands/HydeBuildRssFeedCommand.php
@@ -58,7 +58,7 @@ class HydeBuildRssFeedCommand extends Command
         return true;
     }
 
-    protected function getExecutionTimeInMs(float $timeStart): float
+    protected function getExecutionTimeInMs(float $timeStart): string
     {
         return number_format(((microtime(true) - $timeStart) * 1000), 2);
     }

--- a/src/Commands/HydeBuildSearchCommand.php
+++ b/src/Commands/HydeBuildSearchCommand.php
@@ -8,7 +8,9 @@ use LaravelZero\Framework\Commands\Command;
 
 /**
  * Hyde Command to run the Build Process for the DocumentationSearchIndex.
- *
+ * 
+ * @todo Add configuration option to enable/disable this feature.
+ * 
  * @see \Tests\Feature\Commands\HydeBuildSearchCommandTest
  */
 class HydeBuildSearchCommand extends Command

--- a/src/Commands/HydeBuildSearchCommand.php
+++ b/src/Commands/HydeBuildSearchCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Hyde\Framework\Commands;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile;
+use LaravelZero\Framework\Commands\Command;
+
+/**
+ * Hyde Command to run the Build Process for the DocumentationSearchIndex.
+ *
+ * @see \Tests\Feature\Commands\HydeBuildSearchCommandTest
+ */
+class HydeBuildSearchCommand extends Command
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'build:search';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Generate the docs/search.json';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $actionTime = microtime(true);
+
+        $this->comment('Generating documentation site search index...');
+		GeneratesDocumentationSearchIndexFile::run();
+        $this->line(' > Created <info>'.GeneratesDocumentationSearchIndexFile::$filePath.'</> in '.
+            $this->getExecutionTimeInMs($actionTime)."ms\n");
+
+        return 0;
+    }
+
+    protected function getExecutionTimeInMs(float $timeStart): float
+    {
+        return number_format(((microtime(true) - $timeStart) * 1000), 2);
+    }
+}

--- a/src/Commands/HydeBuildSearchCommand.php
+++ b/src/Commands/HydeBuildSearchCommand.php
@@ -46,7 +46,7 @@ class HydeBuildSearchCommand extends Command
         return 0;
     }
 
-    protected function getExecutionTimeInMs(float $timeStart): float
+    protected function getExecutionTimeInMs(float $timeStart): string
     {
         return number_format(((microtime(true) - $timeStart) * 1000), 2);
     }

--- a/src/Commands/HydeBuildSitemapCommand.php
+++ b/src/Commands/HydeBuildSitemapCommand.php
@@ -58,7 +58,7 @@ class HydeBuildSitemapCommand extends Command
         return true;
     }
 
-    protected function getExecutionTimeInMs(float $timeStart): float
+    protected function getExecutionTimeInMs(float $timeStart): string
     {
         return number_format(((microtime(true) - $timeStart) * 1000), 2);
     }

--- a/src/HydeServiceProvider.php
+++ b/src/HydeServiceProvider.php
@@ -70,6 +70,7 @@ class HydeServiceProvider extends ServiceProvider
             Commands\HydeBuildStaticSiteCommand::class,
             Commands\HydeBuildSitemapCommand::class,
             Commands\HydeBuildRssFeedCommand::class,
+            Commands\HydeBuildSearchCommand::class,
             Commands\HydeMakePostCommand::class,
             Commands\HydeMakePageCommand::class,
             Commands\HydeValidateCommand::class,

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -64,7 +64,7 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
     {
         (new Action())->save();
 
-        $this->assertFileExists('_site/docs/searchIndex.json');
+        $this->assertFileExists('_site/docs/search.json');
     }
 
     public function test_generate_page_object_method_generates_a_page_object()

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -80,6 +80,23 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         );
     }
 
+    // Test it generates a valid JSON 
+    public function test_it_generates_a_valid_JSON()
+    {
+        file_put_contents(Hyde::path('_docs/foo.md'), "# Bar\n\n Hello World");
+        file_put_contents(Hyde::path('_docs/bar.md'), "# Foo\n\n Hello World");
+
+
+        $this->assertEquals(
+            '[{"slug":"bar","title":"Foo"},{"slug":"foo","title":"Bar"}]',
+            (new Action())->generate()->getJson()
+        );
+
+        unlink(Hyde::path('_docs/foo.md'));
+        unlink(Hyde::path('_docs/bar.md'));
+    }
+
+
     // Test it generates a JSON file with a search index
 
     // Test it handles generation even when there are no pages

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -131,4 +131,22 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         unlink(Hyde::path('_docs/foo.md'));
         unlink(Hyde::path('_docs/bar.md'));
     }
+
+    public function test_get_destination_for_slug_returns_empty_string_for_index_when_pretty_url_is_enabled()
+    {
+        config(['hyde.pretty_urls' => true]);
+
+        $this->assertEquals(
+            '', (new Action())->getDestinationForSlug('index')
+        );
+    }
+
+    public function test_get_destination_for_slug_returns_pretty_url_when_enabled()
+    {
+        config(['hyde.pretty_urls' => true]);
+
+        $this->assertEquals(
+            'foo', (new Action())->getDestinationForSlug('foo')
+        );
+    }
 }

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -3,12 +3,38 @@
 namespace Tests\Feature\Actions;
 
 use Tests\TestCase;
-use Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile;
+use Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile as Action;
 
 /**
  * @covers \Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile
  */
 class GeneratesDocumentationSearchIndexFileTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
 
+        unlinkIfExists(Action::$filePath);
+    }
+
+    protected function tearDown(): void
+    {
+        unlinkIfExists(Action::$filePath);
+
+        parent::tearDown();
+    }
+
+
+    // Test save method saves the file to the correct location.
+    public function test_save_method_saves_the_file_to_the_correct_location()
+    {
+        (new Action())->save();
+
+        $this->assertFileExists('_site/docs/searchIndex.json');
+    }
+
+
+    // Test it generates a JSON file with a search index
+
+    // Test it handles generation even when there are no pages
 }

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -51,6 +51,35 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         unlink(Hyde::path('_docs/foo.md'));
     }
 
+    // Test getSourceFileSlugs returns valid array for source files
+    public function test_get_source_file_slugs_returns_valid_array_for_source_files()
+    {
+        touch(Hyde::path('_docs/a.md'));
+        touch(Hyde::path('_docs/b.md'));
+        touch(Hyde::path('_docs/c.md'));
+
+        $this->assertEquals(
+            [
+                'a',
+                'b',
+                'c',
+            ],
+            (new Action())->getSourceFileSlugs()
+        );
+
+        unlink(Hyde::path('_docs/a.md'));
+        unlink(Hyde::path('_docs/b.md'));
+        unlink(Hyde::path('_docs/c.md'));
+    }
+
+    // Test getSourceFileSlugs returns empty array when no source files exists
+    public function test_get_source_file_slugs_returns_empty_array_when_no_source_files_exists()
+    {
+        $this->assertEquals(
+            [], (new Action())->getSourceFileSlugs()
+        );
+    }
+
     // Test it generates a JSON file with a search index
 
     // Test it handles generation even when there are no pages

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Actions;
 
 use Tests\TestCase;
 use Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile as Action;
+use Hyde\Framework\Hyde;
 
 /**
  * @covers \Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile
@@ -33,6 +34,22 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         $this->assertFileExists('_site/docs/searchIndex.json');
     }
 
+    // Test generatePageObject method generates a page object.
+    public function test_generate_page_object_method_generates_a_page_object()
+    {
+        $expected = new \stdClass;
+        $expected->slug = "foo";
+        $expected->title = "Bar";
+
+        file_put_contents(Hyde::path('_docs/foo.md'), "# Bar\n\n Hello World");
+
+        $this->assertEquals(
+            $expected,
+            (new Action())->generatePageObject('foo')
+        );
+
+        unlink(Hyde::path('_docs/foo.md'));
+    }
 
     // Test it generates a JSON file with a search index
 

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -25,6 +25,42 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         parent::tearDown();
     }
 
+    // Test it generates a JSON file with a search index
+    public function test_it_generates_a_JSON_file_with_a_search_index()
+    {
+        touch(Hyde::path('_docs/foo.md'));
+        touch(Hyde::path('_docs/bar.md'));
+
+        $expected = [
+            [
+                'slug' => 'bar',
+                'title' => 'Bar',
+            ],
+            [
+                'slug' => 'foo',
+                'title' => 'Foo',
+            ],
+        ];
+
+        Action::run();
+        
+        $this->assertEquals(
+            json_encode($expected), file_get_contents(Action::$filePath)
+        );
+
+        unlink(Hyde::path('_docs/foo.md'));
+        unlink(Hyde::path('_docs/bar.md'));
+    }
+
+    // Test it handles generation even when there are no pages
+    public function test_it_handles_generation_even_when_there_are_no_pages()
+    {
+        Action::run();
+
+        $this->assertEquals(
+            '[]', file_get_contents(Action::$filePath)
+        );
+    }
 
     // Test save method saves the file to the correct location.
     public function test_save_method_saves_the_file_to_the_correct_location()
@@ -89,9 +125,4 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         unlink(Hyde::path('_docs/foo.md'));
         unlink(Hyde::path('_docs/bar.md'));
     }
-
-
-    // Test it generates a JSON file with a search index
-
-    // Test it handles generation even when there are no pages
 }

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -44,8 +44,7 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         file_put_contents(Hyde::path('_docs/foo.md'), "# Bar\n\n Hello World");
 
         $this->assertEquals(
-            $expected,
-            (new Action())->generatePageObject('foo')
+            $expected, (new Action())->generatePageObject('foo')
         );
 
         unlink(Hyde::path('_docs/foo.md'));
@@ -59,12 +58,7 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         touch(Hyde::path('_docs/c.md'));
 
         $this->assertEquals(
-            [
-                'a',
-                'b',
-                'c',
-            ],
-            (new Action())->getSourceFileSlugs()
+            ['a', 'b', 'c'], (new Action())->getSourceFileSlugs()
         );
 
         unlink(Hyde::path('_docs/a.md'));

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -28,16 +28,13 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
     public function test_it_generates_a_JSON_file_with_a_search_index()
     {
         touch(Hyde::path('_docs/foo.md'));
-        touch(Hyde::path('_docs/bar.md'));
 
         $expected = [
             [
-                'slug' => 'bar',
-                'title' => 'Bar',
-            ],
-            [
                 'slug' => 'foo',
                 'title' => 'Foo',
+                'content' => '',
+                'destination' => 'foo.html',
             ],
         ];
 
@@ -48,8 +45,22 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         );
 
         unlink(Hyde::path('_docs/foo.md'));
-        unlink(Hyde::path('_docs/bar.md'));
     }
+
+
+    public function test_it_adds_all_files_to_search_index()
+    {
+        touch(Hyde::path('_docs/foo.md'));
+        touch(Hyde::path('_docs/bar.md'));
+        touch(Hyde::path('_docs/baz.md'));
+
+        $this->assertCount(3, (new Action())->generate()->searchIndex);
+
+        unlink(Hyde::path('_docs/foo.md'));
+        unlink(Hyde::path('_docs/bar.md'));
+        unlink(Hyde::path('_docs/baz.md'));
+    }
+
 
     public function test_it_handles_generation_even_when_there_are_no_pages()
     {
@@ -72,6 +83,8 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         $expected = new \stdClass;
         $expected->slug = 'foo';
         $expected->title = 'Bar';
+        $expected->content = "Bar \n Hello World";
+        $expected->destination = 'foo.html';
 
         file_put_contents(Hyde::path('_docs/foo.md'), "# Bar\n\n Hello World");
 
@@ -110,7 +123,8 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         file_put_contents(Hyde::path('_docs/bar.md'), "# Foo\n\n Hello World");
 
         $this->assertEquals(
-            '[{"slug":"bar","title":"Foo"},{"slug":"foo","title":"Bar"}]',
+            '[{"slug":"bar","title":"Foo","content":"Foo \n Hello World","destination":"bar.html"},' .
+            '{"slug":"foo","title":"Bar","content":"Bar \n Hello World","destination":"foo.html"}]',
             (new Action())->generate()->getJson()
         );
 

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -25,7 +25,6 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         parent::tearDown();
     }
 
-    // Test it generates a JSON file with a search index
     public function test_it_generates_a_JSON_file_with_a_search_index()
     {
         touch(Hyde::path('_docs/foo.md'));
@@ -52,7 +51,6 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         unlink(Hyde::path('_docs/bar.md'));
     }
 
-    // Test it handles generation even when there are no pages
     public function test_it_handles_generation_even_when_there_are_no_pages()
     {
         Action::run();
@@ -62,7 +60,6 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         );
     }
 
-    // Test save method saves the file to the correct location.
     public function test_save_method_saves_the_file_to_the_correct_location()
     {
         (new Action())->save();
@@ -70,7 +67,6 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         $this->assertFileExists('_site/docs/searchIndex.json');
     }
 
-    // Test generatePageObject method generates a page object.
     public function test_generate_page_object_method_generates_a_page_object()
     {
         $expected = new \stdClass;
@@ -86,7 +82,6 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         unlink(Hyde::path('_docs/foo.md'));
     }
 
-    // Test getSourceFileSlugs returns valid array for source files
     public function test_get_source_file_slugs_returns_valid_array_for_source_files()
     {
         touch(Hyde::path('_docs/a.md'));
@@ -102,7 +97,6 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         unlink(Hyde::path('_docs/c.md'));
     }
 
-    // Test getSourceFileSlugs returns empty array when no source files exists
     public function test_get_source_file_slugs_returns_empty_array_when_no_source_files_exists()
     {
         $this->assertEquals(
@@ -110,7 +104,6 @@ class GeneratesDocumentationSearchIndexFileTest extends TestCase
         );
     }
 
-    // Test it generates a valid JSON 
     public function test_it_generates_a_valid_JSON()
     {
         file_put_contents(Hyde::path('_docs/foo.md'), "# Bar\n\n Hello World");

--- a/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
+++ b/tests/Feature/Actions/GeneratesDocumentationSearchIndexFileTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Feature\Actions;
+
+use Tests\TestCase;
+use Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile;
+
+/**
+ * @covers \Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile
+ */
+class GeneratesDocumentationSearchIndexFileTest extends TestCase
+{
+
+}

--- a/tests/Feature/Commands/HydeBuildSearchCommandTest.php
+++ b/tests/Feature/Commands/HydeBuildSearchCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature\Commands;
+
+use Hyde\Framework\Hyde;
+use Tests\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Commands\HydeBuildSearchCommand
+ */
+class HydeBuildSearchCommandTest extends TestCase
+{
+	public function test_it_creates_the_search_json_file()
+    {
+        unlinkIfExists(Hyde::path('_site/docs/search.json'));
+        $this->artisan('build:search')
+            ->expectsOutput('Generating documentation site search index...')
+            ->assertExitCode(0);
+
+        $this->assertFileExists(Hyde::path('_site/docs/search.json'));
+        unlink(Hyde::path('_site/docs/search.json'));
+    }
+}


### PR DESCRIPTION
## About

Adds an action which generates a search index for documentation pages used for the [HydeSearch plugin](https://github.com/caendesilva/HydeSearch)

## How it works

The way it currently works is that it takes a plain-text representation of all Markdown documentation pages and adds them paired with metadata such as the page title and URI path.

It is pretty slow to generate, so I have not yet added it to the `hyde build` command. Instead, it's generated using `php hyde build:search`.

The reason it's slow, is that each Markdown page needs to be parsed into a Page model, then the Markdown body is compiled to HTML as I found that to be the easiest way to convert it to plain text (using regex).

## Benchmarks

> These are not at all proper benchmarks, but an approximate of how long it took on my machine.

Generating a search index for the entire Hyde documentation took around 930ms and the resulting JSON is about 80KB.

Generating a search index for the entire Alice's Adventures in Wonderland book (where each chapter is a Markdown file) took around 1300ms. The JSON is around 148kB. When testing in production, only 55.2 kB is sent over the air, which is then cacheable resulting in a browser load time of about 2ms.

## Try it out

Try a live demo of the frontend implementation using the entire Wonderland book:
https://demos.desilva.se/gist/github/hydephp/experiments/hydesearch/