### PR TITLE
Skip generating auxiliary files in the main built loop when there is no underlying content

### DIFF
--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -215,7 +215,8 @@ class HydeBuildStaticSiteCommand extends Command
 
     protected function canGenerateFeed(): bool
     {
-        return RssFeedService::canGenerateFeed();
+        return RssFeedService::canGenerateFeed()
+            && count(CollectionService::getMarkdownPostList()) > 0;
     }
 
     protected function canGenerateSearch(): bool

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -129,6 +129,8 @@ class BuildStaticSiteCommandTest extends TestCase
         config(['hyde.site_url' => 'https://example.com']);
         config(['hyde.generate_rss_feed' => true]);
 
+        touch(Hyde::path('_posts/foo.md'));
+
         $this->artisan('build')
             ->expectsOutput('Generating RSS feed...')
             ->assertExitCode(0);

--- a/tests/Feature/Commands/BuildStaticSiteCommandTest.php
+++ b/tests/Feature/Commands/BuildStaticSiteCommandTest.php
@@ -136,6 +136,24 @@ class BuildStaticSiteCommandTest extends TestCase
         unlink(Hyde::path('_site/feed.xml'));
     }
 
+    public function test_does_not_generate_search_files_when_conditions_are_not_met()
+    {
+        $this->artisan('build')
+            ->doesntExpectOutput('Generating documentation site search index...')
+            ->doesntExpectOutput('Generating search page...')
+            ->assertExitCode(0);
+    }
+
+    public function test_generates_search_files_when_conditions_are_met()
+    {
+        touch(Hyde::path('_docs/foo.md'));
+
+        $this->artisan('build')
+            ->expectsOutput('Generating documentation site search index...')
+            ->expectsOutput('Generating search page...')
+            ->assertExitCode(0);
+    }
+
     /**
      * Added for code coverage, deprecated as the pretty flag is deprecated.
      *


### PR DESCRIPTION
Fixes https://github.com/hydephp/framework/issues/482 and https://github.com/hydephp/framework/issues/482#issuecomment-1146645266

Now checks if there are blog posts before creating the RSS feed, and if there are documentation pages before generating the search page and JSON index.

Note that this only changes behaviour for the `php hyde build` command. You can still generate the files by calling `build:rss` and `build:search`.