### PR TITLE
v0.36.x - Add package auto-discovery

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Hyde\Framework;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\PackageManifest;
+
+class Application extends \LaravelZero\Framework\Application
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function registerBaseBindings(): void
+    {
+        parent::registerBaseBindings();
+
+        /*
+         * Enable auto-discovery.
+         */
+        $this->app->singleton(PackageManifest::class, function () {
+            return new PackageManifest(
+                new Filesystem, $this->basePath(), $this->basePath('storage/framework/cache/packages.php')
+            );
+        });
+    }
+}

--- a/src/Commands/HydePackageDiscoverCommand.php
+++ b/src/Commands/HydePackageDiscoverCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Hyde\Framework\Commands;
+
+use Hyde\Framework\Hyde;
+use Illuminate\Foundation\Console\PackageDiscoverCommand as BaseCommand;
+use Illuminate\Foundation\PackageManifest;
+
+class HydePackageDiscoverCommand extends BaseCommand
+{
+    protected $hidden = true;
+
+    public function handle(PackageManifest $manifest)
+    {
+        $manifest->manifestPath = Hyde::path('storage/framework/cache/packages.php');
+        parent::handle($manifest);
+    }
+}

--- a/src/HydeServiceProvider.php
+++ b/src/HydeServiceProvider.php
@@ -77,6 +77,8 @@ class HydeServiceProvider extends ServiceProvider
             Commands\HydeInstallCommand::class,
             Commands\HydeDebugCommand::class,
             Commands\HydeServeCommand::class,
+
+            Commands\HydePackageDiscoverCommand::class,
         ]);
     }
 


### PR DESCRIPTION
Creates a Laravel Application to enable auto discovery of packages and service providers.
Also adds a command to create the cache of discovered packages. `php hyde packages:discover`.