### PR TITLE
Merge pull request #48 from hydephp/Skip-test-if-the-_docs-directory-is-empty

### DIFF
--- a/src/Services/ValidationService.php
+++ b/src/Services/ValidationService.php
@@ -66,6 +66,10 @@ class ValidationService
             return $result->skip('The documentation page feature is disabled in config');
         }
 
+        if (count(CollectionService::getDocumentationPageList()) === 0) {
+            return $result->skip('There are no documentation pages');
+        }
+
         if (file_exists('_docs/index.md')) {
             return $result->pass('Your documentation site has an index page');
         }


### PR DESCRIPTION
Skip documentation index validation test if the _docs directory is empty