### PR TITLE
v0.41.0-beta - 2022-06-24 - Improve the AssetService

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         php: [8.0, 8.1]
-        dependency-version: [prefer-lowest, prefer-stable]
-
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -35,8 +33,6 @@ jobs:
 
       - name: Install Dependencies
         run: cd hyde && composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-      - name: Set dependency version
-        run: cd hyde && composer update --${{ matrix.dependency-version }}
 
       - name: Remove Hyde tests (Unix)
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,7 +34,9 @@ jobs:
         run: "cd hyde && composer require hyde/framework:dev-master"
 
       - name: Install Dependencies
-        run: cd hyde && composer install --no-ansi --no-interaction --no-scripts --no-progress --${{ matrix.dependency-version }} --prefer-dist
+        run: cd hyde && composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+      - name: Set dependency version
+        run: cd hyde && composer update --${{ matrix.dependency-version }}
 
       - name: Remove Hyde tests (Unix)
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         php: [8.0, 8.1]
+        dependency-version: [prefer-lowest, prefer-stable]
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -32,7 +34,7 @@ jobs:
         run: "cd hyde && composer require hyde/framework:dev-master"
 
       - name: Install Dependencies
-        run: cd hyde && composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+        run: cd hyde && composer install --no-ansi --no-interaction --no-scripts --no-progress --${{ matrix.dependency-version }} --prefer-dist
 
       - name: Remove Hyde tests (Unix)
         if: matrix.os != 'windows-latest'

--- a/resources/views/layouts/scripts.blade.php
+++ b/resources/views/layouts/scripts.blade.php
@@ -1,10 +1,12 @@
 {{-- The core HydeFront scripts --}}
-@if(Hyde::scripts())
-<script defer src="{{ Hyde::scripts() }}"></script>
-@endif
+@unless(Asset::hasMediaFile('hyde.js'))
+<script defer src="{{ Asset::cdnLink('hyde.js') }}"></script>
+@else
+<script defer src="{{ Hyde::relativeLink('media/hyde.js', $currentPage) }}"></script>
+@endunless
 
 {{-- The compiled Laravel Mix scripts --}}
-@if(Hyde::assetManager()->hasMediaFile('app.js'))
+@if(Asset::hasMediaFile('app.js'))
 <script defer src="{{ Hyde::relativeLink('media/app.js', $currentPage) }}"></script>
 @endif
 

--- a/resources/views/layouts/styles.blade.php
+++ b/resources/views/layouts/styles.blade.php
@@ -1,10 +1,12 @@
 {{-- The core HydeFront stylesheet --}}
-@if(Hyde::styles())
-<link rel="stylesheet" href="{{ Hyde::styles() }}">
-@endif
+@unless(Asset::hasMediaFile('hyde.css'))
+<link rel="stylesheet" href="{{ Asset::cdnLink('hyde.css') }}">
+@else
+<link rel="stylesheet" href="{{ Hyde::relativeLink('media/hyde.css', $currentPage) }}">
+@endunless
 
 {{-- The compiled Tailwind/App styles --}}
-@if(Hyde::assetManager()->hasMediaFile('app.css'))
+@if(Asset::hasMediaFile('app.css'))
 <link rel="stylesheet" href="{{ Hyde::relativeLink('media/app.css', $currentPage) }}">
 @endif
 

--- a/src/Concerns/Internal/AssetManager.php
+++ b/src/Concerns/Internal/AssetManager.php
@@ -7,12 +7,15 @@ use Hyde\Framework\Contracts\AssetServiceContract;
 /**
  * Offloads asset related methods for the Hyde Facade.
  *
+ * @deprecated version 0.41.x - Use the Asset facade instead.
  * @see \Hyde\Framework\Hyde
  */
 trait AssetManager
 {
     /**
      * Get the asset service instance.
+     *
+     * @deprecated version 0.41.x - Use the Asset facade instead.
      *
      * @return \Hyde\Framework\Contracts\AssetServiceContract
      */
@@ -23,6 +26,8 @@ trait AssetManager
 
     /**
      * Return the Hyde stylesheet.
+     *
+     * @deprecated version 0.41.x - Use the Asset facade instead.
      */
     public static function styles(): string
     {
@@ -31,6 +36,8 @@ trait AssetManager
 
     /**
      * Return the Hyde scripts.
+     *
+     * @deprecated version 0.41.x - Use the Asset facade instead.
      */
     public static function scripts(): string
     {

--- a/src/Facades/Asset.php
+++ b/src/Facades/Asset.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Hyde\Framework\Facades;
+
+use Hyde\Framework\Contracts\AssetServiceContract;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @see \Hyde\Framework\Services\AssetService
+ *
+ * @method static string version()
+ * @method static string stylePath()
+ * @method static string scriptPath()
+ * @method static string constructCdnPath(string $file)
+ * @method static string cdnLink(string $file)
+ * @method static bool hasMediaFile(string $file)
+ */
+class Asset extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return AssetServiceContract::class;
+    }
+}

--- a/src/Services/AssetService.php
+++ b/src/Services/AssetService.php
@@ -5,6 +5,9 @@ namespace Hyde\Framework\Services;
 use Hyde\Framework\Contracts\AssetServiceContract;
 use Hyde\Framework\Hyde;
 
+/**
+ * @see \Hyde\Framework\Facades\Asset
+ */
 class AssetService implements AssetServiceContract
 {
     /**
@@ -32,6 +35,16 @@ class AssetService implements AssetServiceContract
     public function constructCdnPath(string $file): string
     {
         return 'https://cdn.jsdelivr.net/npm/hydefront@'.$this->version().'/dist/'.$file;
+    }
+
+    /**
+     * Alias for constructCdnPath.
+     *
+     * @since v0.41.x
+     */
+    public function cdnLink(string $file): string
+    {
+        return $this->constructCdnPath($file);
     }
 
     public function hasMediaFile(string $file): bool

--- a/tests/Unit/AssetFacadeTest.php
+++ b/tests/Unit/AssetFacadeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Hyde\Framework\Contracts\AssetServiceContract;
+use Hyde\Framework\Facades\Asset;
+use Hyde\Framework\Services\AssetService;
+use Hyde\Testing\TestCase;
+
+/**
+ * @covers \Hyde\Framework\Facades\Asset
+ */
+class AssetFacadeTest extends TestCase
+{
+    public function test_asset_facade_returns_the_asset_service()
+    {
+        $this->assertInstanceOf(AssetServiceContract::class, Asset::getFacadeRoot());
+    }
+
+    public function test_facade_returns_same_instance_as_bound_by_the_container()
+    {
+        $this->assertSame(Asset::getFacadeRoot(), app(AssetServiceContract::class));
+    }
+
+    public function test_asset_facade_can_call_methods_on_the_asset_service()
+    {
+        $service = new AssetService();
+        $this->assertEquals($service->version(), Asset::version());
+    }
+}

--- a/tests/Unit/Views/ScriptsComponentViewTest.php
+++ b/tests/Unit/Views/ScriptsComponentViewTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Hyde\Framework\Testing\Unit\Views;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Services\AssetService;
+use Hyde\Testing\TestCase;
+use Illuminate\Support\Facades\Blade;
+
+/**
+ * @see resources/views/layouts/scripts.blade.php
+ */
+class ScriptsComponentViewTest extends TestCase
+{
+    protected ?string $mockCurrentPage = null;
+
+    protected function renderTestView(): string
+    {
+        view()->share('currentPage', $this->mockCurrentPage ?? '');
+
+        return Blade::render(file_get_contents(
+            Hyde::vendorPath('resources/views/layouts/scripts.blade.php')
+        ));
+    }
+
+    public function test_component_can_be_rendered()
+    {
+        $this->assertStringContainsString('<script defer', $this->renderTestView());
+    }
+
+    public function test_component_has_link_to_app_js_file_when_it_exists()
+    {
+        touch(Hyde::path('_media/app.js'));
+        $this->assertStringContainsString('<script defer src="media/app.js"', $this->renderTestView());
+        unlink(Hyde::path('_media/app.js'));
+    }
+
+    public function test_component_does_not_render_link_to_app_js_when_it_does_not_exist()
+    {
+        $this->assertStringNotContainsString('<script defer src="media/app.js"', $this->renderTestView());
+    }
+
+    public function test_component_uses_relative_path_to_app_js_file_for_nested_pages()
+    {
+        touch(Hyde::path('_media/app.js'));
+        $this->mockCurrentPage = 'foo';
+        $this->assertStringContainsString('<script defer src="media/app.js"', $this->renderTestView());
+        $this->mockCurrentPage = 'foo/bar';
+        $this->assertStringContainsString('<script defer src="../media/app.js"', $this->renderTestView());
+        $this->mockCurrentPage = 'foo/bar/cat.html';
+        $this->assertStringContainsString('<script defer src="../../media/app.js"', $this->renderTestView());
+        $this->mockCurrentPage = null;
+        unlink(Hyde::path('_media/app.js'));
+    }
+
+    public function test_scripts_can_be_pushed_to_the_component_scripts_stack()
+    {
+        view()->share('currentPage', '');
+
+        $this->assertStringContainsString('foo bar',
+             Blade::render('
+                @push("scripts")
+                foo bar
+                @endpush
+                
+                @include("hyde::layouts.scripts")'
+             )
+        );
+    }
+
+    public function test_component_renders_link_to_hyde_js_when_it_exists()
+    {
+        touch(Hyde::path('_media/hyde.js'));
+        $this->assertStringContainsString('<script defer src="media/hyde.js"', $this->renderTestView());
+        unlink(Hyde::path('_media/hyde.js'));
+    }
+
+    public function test_component_does_not_render_link_to_hyde_js_when_it_does_not_exist()
+    {
+        $this->assertStringNotContainsString('<script defer src="media/hyde.js"', $this->renderTestView());
+    }
+
+    public function test_component_renders_cdn_link_when_no_local_file_exists()
+    {
+        $this->assertStringContainsString('https://cdn.jsdelivr.net/npm/hydefront', $this->renderTestView());
+    }
+
+    public function test_component_does_not_render_cdn_link_when_a_local_file_exists()
+    {
+        touch(Hyde::path('_media/hyde.js'));
+        $this->assertStringNotContainsString('https://cdn.jsdelivr.net/npm/hydefront', $this->renderTestView());
+        unlink(Hyde::path('_media/hyde.js'));
+    }
+
+    public function test_cdn_link_uses_the_correct_version_defined_in_the_asset_manager()
+    {
+        $expectedVersion = (new AssetService)->version();
+        $this->assertStringContainsString(
+            'https://cdn.jsdelivr.net/npm/hydefront@'.$expectedVersion.'/dist/hyde.js',
+            $this->renderTestView()
+        );
+    }
+}

--- a/tests/Unit/Views/StylesComponentViewTest.php
+++ b/tests/Unit/Views/StylesComponentViewTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Hyde\Framework\Testing\Unit\Views;
+
+use Hyde\Framework\Hyde;
+use Hyde\Framework\Services\AssetService;
+use Hyde\Testing\TestCase;
+use Illuminate\Support\Facades\Blade;
+
+/**
+ * @see resources/views/layouts/styles.blade.php
+ */
+class StylesComponentViewTest extends TestCase
+{
+    protected ?string $mockCurrentPage = null;
+
+    protected function renderTestView(): string
+    {
+        view()->share('currentPage', $this->mockCurrentPage ?? '');
+
+        return Blade::render(file_get_contents(
+            Hyde::vendorPath('resources/views/layouts/styles.blade.php')
+        ));
+    }
+
+    public function test_component_can_be_rendered()
+    {
+        $this->assertStringContainsString('<link rel="stylesheet"', $this->renderTestView());
+    }
+
+    public function test_component_has_link_to_app_css_file()
+    {
+        $this->assertStringContainsString('<link rel="stylesheet" href="media/app.css"', $this->renderTestView());
+    }
+
+    public function test_component_uses_relative_path_to_app_css_file_for_nested_pages()
+    {
+        $this->mockCurrentPage = 'foo';
+        $this->assertStringContainsString('<link rel="stylesheet" href="media/app.css"', $this->renderTestView());
+        $this->mockCurrentPage = 'foo/bar';
+        $this->assertStringContainsString('<link rel="stylesheet" href="../media/app.css"', $this->renderTestView());
+        $this->mockCurrentPage = 'foo/bar/cat.html';
+        $this->assertStringContainsString('<link rel="stylesheet" href="../../media/app.css"', $this->renderTestView());
+        $this->mockCurrentPage = null;
+    }
+
+    public function test_component_does_not_render_link_to_app_css_when_it_does_not_exist()
+    {
+        rename(Hyde::path('_media/app.css'), Hyde::path('_media/app.css.bak'));
+        $this->assertStringNotContainsString('<link rel="stylesheet" href="media/app.css"', $this->renderTestView());
+        rename(Hyde::path('_media/app.css.bak'), Hyde::path('_media/app.css'));
+    }
+
+    public function test_styles_can_be_pushed_to_the_component_styles_stack()
+    {
+        view()->share('currentPage', '');
+
+        $this->assertStringContainsString('foo bar',
+             Blade::render('
+                @push("styles")
+                foo bar
+                @endpush
+                
+                @include("hyde::layouts.styles")'
+             )
+        );
+    }
+
+    public function test_component_renders_link_to_hyde_css_when_it_exists()
+    {
+        touch(Hyde::path('_media/hyde.css'));
+        $this->assertStringContainsString('<link rel="stylesheet" href="media/hyde.css"', $this->renderTestView());
+        unlink(Hyde::path('_media/hyde.css'));
+    }
+
+    public function test_component_does_not_render_link_to_hyde_css_when_it_does_not_exist()
+    {
+        $this->assertStringNotContainsString('<link rel="stylesheet" href="media/hyde.css"', $this->renderTestView());
+    }
+
+    public function test_component_renders_cdn_link_when_no_local_file_exists()
+    {
+        $this->assertStringContainsString('https://cdn.jsdelivr.net/npm/hydefront', $this->renderTestView());
+    }
+
+    public function test_component_does_not_render_cdn_link_when_a_local_file_exists()
+    {
+        touch(Hyde::path('_media/hyde.css'));
+        $this->assertStringNotContainsString('https://cdn.jsdelivr.net/npm/hydefront', $this->renderTestView());
+        unlink(Hyde::path('_media/hyde.css'));
+    }
+
+    public function test_cdn_link_uses_the_correct_version_defined_in_the_asset_manager()
+    {
+        $expectedVersion = (new AssetService)->version();
+        $this->assertStringContainsString(
+            'https://cdn.jsdelivr.net/npm/hydefront@'.$expectedVersion.'/dist/hyde.css',
+            $this->renderTestView()
+        );
+    }
+}


### PR DESCRIPTION
### About

This release refactors and improves the Asset Service, adding auto-configuration features and a new Asset facade.

#### Using the Asset facade in Blade views

Instead of the long syntax `Hyde::assetManager()` you can now use the `Asset` facade directly. See this example, which both do the exact same thing using the same underlying service:

```blade
Hyde::assetManager()->hasMediaFile('app.css')
Asset::hasMediaFile('app.css')
```

If you don't know what any of this means, good news! You don't have to worry about it. Hyde's got your back.

### Added
- Added feature to dynamically load hyde.css and hyde.js if they exist locally
- Added the Asset facade to be used instead of `Hyde::assetManager()`
- Added the Asset facade as a class alias to `config/app.css`

### Changed
- Changed `scripts.blade.php` and `styles.blade.php` to use the Asset facade

### Deprecated
- Deprecated AssetManager.php (`Hyde::assetManager()`). Use the Asset facade instead
