### PR TITLE
Fix #102 Add glob pattern to Prettier command

### DIFF
--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -128,6 +128,7 @@ class HydeBuildStaticSiteCommand extends Command
             $this->runNodeCommand(
                 'npx prettier '.Hyde::pathToRelative(Hyde::getSiteOutputPath()).'/**/*.html --write --bracket-same-line',
                 'Prettifying code!',
+                'prettify code'
             );
         }
 

--- a/src/Commands/HydeBuildStaticSiteCommand.php
+++ b/src/Commands/HydeBuildStaticSiteCommand.php
@@ -126,9 +126,8 @@ class HydeBuildStaticSiteCommand extends Command
                 $this->warn('<error>Warning:</> The --pretty option is deprecated, use --run-prettier instead');
             }
             $this->runNodeCommand(
-                'npx prettier '.Hyde::pathToRelative(Hyde::getSiteOutputPath()).'/ --write --bracket-same-line',
+                'npx prettier '.Hyde::pathToRelative(Hyde::getSiteOutputPath()).'/**/*.html --write --bracket-same-line',
                 'Prettifying code!',
-                'prettify code'
             );
         }
 


### PR DESCRIPTION
Fix https://github.com/hydephp/develop/issues/102 Change Prettier integration to only modify HTML files https://github.com/hydephp/develop/commit/b81724f80e6177ed97097d663bca130ab072bee7

In HydeBuildStaticSiteCommand.php

```diff
- 'npx prettier '.Hyde::pathToRelative(Hyde::getSiteOutputPath()).'/ --write --bracket-same-line',
+ 'npx prettier '.Hyde::pathToRelative(Hyde::getSiteOutputPath()).'/**/*.html --write --bracket-same-line',
```