### PR TITLE
Improve the full page documentation search

### DIFF
--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -67,6 +67,9 @@
 		@endphp
 		<article id="document" itemscope itemtype="http://schema.org/Article" @class(['mx-auto lg:ml-8 prose dark:prose-invert
 			max-w-3xl', 'torchlight-enabled'=> $document->hasTorchlight()])>
+			
+			@yield('content')
+
 			<header id="document-header">
 				{!! $document->renderHeader() !!}
 			</header>

--- a/resources/views/pages/documentation-search.blade.php
+++ b/resources/views/pages/documentation-search.blade.php
@@ -1,3 +1,13 @@
-<h1>Search the documentation site</h1>
-<style>#searchMenuButton{display:none!important;}#search-results{max-height:unset!important;}</style>
-@include('hyde::components.docs.search-input')
+@php
+	$page = new \Hyde\Framework\Models\DocumentationPage([], '', 'Search', 'search');
+	$title = 'Search';
+	$currentPage = $page->getCurrentPagePath();
+	$markdown = '';
+@endphp
+
+@extends('hyde::layouts.docs')
+@section('content')
+	<h1>Search the documentation site</h1>
+	<style>#searchMenuButton{display:none!important;}#search-results{max-height:unset!important;}</style>
+	@include('hyde::components.docs.search-input')
+@endsection

--- a/src/Commands/HydeBuildSearchCommand.php
+++ b/src/Commands/HydeBuildSearchCommand.php
@@ -4,7 +4,6 @@ namespace Hyde\Framework\Commands;
 
 use Hyde\Framework\Actions\GeneratesDocumentationSearchIndexFile;
 use Hyde\Framework\Hyde;
-use Hyde\Framework\Models\DocumentationPage;
 use Hyde\Framework\Services\CollectionService;
 use LaravelZero\Framework\Commands\Command;
 
@@ -61,12 +60,7 @@ class HydeBuildSearchCommand extends Command
         $this->comment('Generating search page...');
         file_put_contents(
             Hyde::path('_site/'.config('docs.output_directory', 'docs').'/search.html'),
-            view('hyde::layouts.docs')->with([
-                'page' => new DocumentationPage([], '', 'Search', 'search'),
-                'title' => 'Search',
-                'markdown' => view('hyde::pages.documentation-search')->render(),
-                'currentPage' => ''.config('docs.output_directory', 'docs').'/search',
-            ])->render()
+            view('hyde::pages.documentation-search')->render()
         );
 
         $this->line(' > Created <info>_site/'.config('docs.output_directory', 'docs').'/search.html</> in '.


### PR DESCRIPTION
## Added
- Added a `@section` hook to the docs layout to allow yielding content

### Changed
- Change the the Prettier integration to only modify HTML files https://github.com/hydephp/develop/issues/102
- Change how the `docs/search.html` page is rendered, by handling page logic in the view, to decouple it from the build search command

### Fixed
- Fix bug https://github.com/hydephp/develop/issues/93 where styles were missing on search.html when changing the output directory to root

