### PR TITLE
Fix wrong HydeFront version constant

### DIFF
--- a/src/Framework/Services/AssetService.php
+++ b/src/Framework/Services/AssetService.php
@@ -31,7 +31,7 @@ use function file_get_contents;
 class AssetService
 {
     /** @var string The default HydeFront SemVer tag to load. This constant is set to match the styles used for the installed framework version. */
-    final public const HYDEFRONT_VERSION = 'v2.0';
+    final public const HYDEFRONT_VERSION = 'v3.0';
 
     /** @var string The default HydeFront CDN path pattern. The Blade-style placeholders are replaced with the proper values. */
     final public const HYDEFRONT_CDN_URL = 'https://cdn.jsdelivr.net/npm/hydefront@{{ $version }}/dist/{{ $file }}';

--- a/src/Framework/Services/AssetService.php
+++ b/src/Framework/Services/AssetService.php
@@ -31,7 +31,7 @@ use function file_get_contents;
 class AssetService
 {
     /** @var string The default HydeFront SemVer tag to load. This constant is set to match the styles used for the installed framework version. */
-    final public const HYDEFRONT_VERSION = 'v3.0';
+    final public const HYDEFRONT_VERSION = 'v3.3';
 
     /** @var string The default HydeFront CDN path pattern. The Blade-style placeholders are replaced with the proper values. */
     final public const HYDEFRONT_CDN_URL = 'https://cdn.jsdelivr.net/npm/hydefront@{{ $version }}/dist/{{ $file }}';

--- a/tests/Unit/AssetServiceUnitTest.php
+++ b/tests/Unit/AssetServiceUnitTest.php
@@ -22,7 +22,7 @@ class AssetServiceUnitTest extends UnitTestCase
 
     public function testVersionStringConstant()
     {
-        $this->assertSame('v2.0', AssetService::HYDEFRONT_VERSION);
+        $this->assertSame('v3.0', AssetService::HYDEFRONT_VERSION);
     }
 
     public function testServiceHasVersionString()
@@ -55,7 +55,7 @@ class AssetServiceUnitTest extends UnitTestCase
     public function testCanUseCustomCdnUrlWithVersion()
     {
         self::mockConfig(['hyde.hydefront_url' => '{{ $version }}']);
-        $this->assertSame('v2.0', (new AssetService())->cdnLink(''));
+        $this->assertSame('v3.0', (new AssetService())->cdnLink(''));
     }
 
     public function testCanUseCustomCdnUrlWithFile()
@@ -67,7 +67,7 @@ class AssetServiceUnitTest extends UnitTestCase
     public function testCanUseCustomCdnUrlWithVersionAndFile()
     {
         self::mockConfig(['hyde.hydefront_url' => '{{ $version }}/{{ $file }}']);
-        $this->assertSame('v2.0/styles.css', (new AssetService())->cdnLink('styles.css'));
+        $this->assertSame('v3.0/styles.css', (new AssetService())->cdnLink('styles.css'));
     }
 
     public function testCanUseCustomCdnUrlWithCustomVersion()
@@ -82,7 +82,7 @@ class AssetServiceUnitTest extends UnitTestCase
     public function testCdnLinkHelper()
     {
         $this->assertSame(
-            'https://cdn.jsdelivr.net/npm/hydefront@v2.0/dist/styles.css',
+            'https://cdn.jsdelivr.net/npm/hydefront@v3.0/dist/styles.css',
             (new AssetService())->cdnLink('styles.css')
         );
     }

--- a/tests/Unit/AssetServiceUnitTest.php
+++ b/tests/Unit/AssetServiceUnitTest.php
@@ -22,7 +22,7 @@ class AssetServiceUnitTest extends UnitTestCase
 
     public function testVersionStringConstant()
     {
-        $this->assertSame('v3.0', AssetService::HYDEFRONT_VERSION);
+        $this->assertSame('v3.3', AssetService::HYDEFRONT_VERSION);
     }
 
     public function testServiceHasVersionString()
@@ -55,7 +55,7 @@ class AssetServiceUnitTest extends UnitTestCase
     public function testCanUseCustomCdnUrlWithVersion()
     {
         self::mockConfig(['hyde.hydefront_url' => '{{ $version }}']);
-        $this->assertSame('v3.0', (new AssetService())->cdnLink(''));
+        $this->assertSame('v3.3', (new AssetService())->cdnLink(''));
     }
 
     public function testCanUseCustomCdnUrlWithFile()
@@ -67,7 +67,7 @@ class AssetServiceUnitTest extends UnitTestCase
     public function testCanUseCustomCdnUrlWithVersionAndFile()
     {
         self::mockConfig(['hyde.hydefront_url' => '{{ $version }}/{{ $file }}']);
-        $this->assertSame('v3.0/styles.css', (new AssetService())->cdnLink('styles.css'));
+        $this->assertSame('v3.3/styles.css', (new AssetService())->cdnLink('styles.css'));
     }
 
     public function testCanUseCustomCdnUrlWithCustomVersion()
@@ -82,7 +82,7 @@ class AssetServiceUnitTest extends UnitTestCase
     public function testCdnLinkHelper()
     {
         $this->assertSame(
-            'https://cdn.jsdelivr.net/npm/hydefront@v3.0/dist/styles.css',
+            'https://cdn.jsdelivr.net/npm/hydefront@v3.3/dist/styles.css',
             (new AssetService())->cdnLink('styles.css')
         );
     }


### PR DESCRIPTION
Cherry-picks https://github.com/hydephp/develop/pull/1323 to master in preparation for a patch release. 