### PR TITLE
Internal: Update test workflow to dynamically install the proper framework version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,13 +33,9 @@ jobs:
         if: "github.ref != 'refs/heads/master'"
         run: git clone -b develop https://github.com/hydephp/hyde.git
 
-      - name: Require latest master version
+      - name: Require proper framework version
         if: "github.ref == 'refs/heads/master'"
-        run: cd hyde && composer require hyde/framework:dev-master --no-install
-
-      - name: Require latest development version
-        if: "github.ref != 'refs/heads/master'"
-        run: cd hyde && composer require hyde/framework:dev-develop --no-install
+        run: cd hyde && composer require hyde/framework:dev-${{ github.head_ref }} --no-install
 
       - name: Install Dependencies
         run: |

--- a/tests/Unit/HydeConfigFilesAreMatchingTest.php
+++ b/tests/Unit/HydeConfigFilesAreMatchingTest.php
@@ -14,6 +14,15 @@ use Hyde\Testing\TestCase;
  */
 class HydeConfigFilesAreMatchingTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (file_exists(Hyde::path('README.md')) && ! str_contains(file_get_contents(Hyde::path('README.md')), 'HydePHP - Source Monorepo')) {
+            $this->markTestSkipped('Test skipped when not running in the monorepo.');
+        }
+    }
+
     public function test_hyde_config_files_are_matching()
     {
         $this->assertFileEqualsIgnoringNewlineType(


### PR DESCRIPTION
Fixes the issue in https://github.com/hydephp/framework/pull/571 which fails due to the workflow checking out the develop branch.

Also cherry picks https://github.com/hydephp/develop/pull/1339: Skip unit test when not running in the monorepo https://github.com/hydephp/develop/commit/48955e572be0e1dcfe279c6e19f23802ce8063f3