### PR TITLE
Fix issues with the sitemap and RSS feed generator commands

### DIFF
--- a/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
+++ b/src/Framework/Actions/PostBuildTasks/GenerateRssFeed.php
@@ -6,24 +6,30 @@ namespace Hyde\Framework\Actions\PostBuildTasks;
 
 use Hyde\Hyde;
 use Hyde\Framework\Features\BuildTasks\PostBuildTask;
+use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Features\XmlGenerators\RssFeedGenerator;
 
 use function file_put_contents;
 
 class GenerateRssFeed extends PostBuildTask
 {
+    use InteractsWithDirectories;
+
     public static string $message = 'Generating RSS feed';
+
+    protected string $path;
 
     public function handle(): void
     {
-        file_put_contents(
-            Hyde::sitePath(RssFeedGenerator::getFilename()),
-            RssFeedGenerator::make()
-        );
+        $this->path = Hyde::sitePath(RssFeedGenerator::getFilename());
+
+        $this->needsParentDirectory($this->path);
+
+        file_put_contents($this->path, RssFeedGenerator::make());
     }
 
     public function printFinishMessage(): void
     {
-        $this->createdSiteFile('_site/'.RssFeedGenerator::getFilename())->withExecutionTime();
+        $this->createdSiteFile($this->path)->withExecutionTime();
     }
 }

--- a/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
+++ b/src/Framework/Actions/PostBuildTasks/GenerateSitemap.php
@@ -6,24 +6,30 @@ namespace Hyde\Framework\Actions\PostBuildTasks;
 
 use Hyde\Hyde;
 use Hyde\Framework\Features\BuildTasks\PostBuildTask;
+use Hyde\Framework\Concerns\InteractsWithDirectories;
 use Hyde\Framework\Features\XmlGenerators\SitemapGenerator;
 
 use function file_put_contents;
 
 class GenerateSitemap extends PostBuildTask
 {
+    use InteractsWithDirectories;
+
     public static string $message = 'Generating sitemap';
+
+    protected string $path;
 
     public function handle(): void
     {
-        file_put_contents(
-            Hyde::sitePath('sitemap.xml'),
-            SitemapGenerator::make()
-        );
+        $this->path = Hyde::sitePath('sitemap.xml');
+
+        $this->needsParentDirectory($this->path);
+
+        file_put_contents($this->path, SitemapGenerator::make());
     }
 
     public function printFinishMessage(): void
     {
-        $this->createdSiteFile('_site/sitemap.xml')->withExecutionTime();
+        $this->createdSiteFile($this->path)->withExecutionTime();
     }
 }


### PR DESCRIPTION
Fixes a bug where the sitemap and RSS feed generator commands did not work when the `_site/` directory was not present, and adds some cleanups to the commands.

Merges pull request https://github.com/hydephp/develop/pull/1654