### PR TITLE
Internal: Improve the test environment setup process

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,6 +35,7 @@ jobs:
 
       # Now, we copy the framework source code to the Hyde project
       - name: Copy over framework source code
+        shell: bash
         run: |
           mkdir -p ./hyde/packages/hyde/framework/src
           rsync -a --exclude=hyde/ ./ ./hyde/packages/hyde/framework/src

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,11 +42,11 @@ jobs:
           # Since we can't use rsync on Windows, we have to setup a temporary directory to copy the files to
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
             mkdir ../temp
-            cp -r ./ ./temp
-            rm -rf ./temp/hyde
+            cp -r ./ ../temp
+            rm -rf ../temp/hyde
             cp -r ./temp/. ./hyde/packages/hyde/framework/src
           else
-              rsync -a --exclude=hyde ./packages/framework/. ./hyde/packages/hyde/framework/src
+              rsync -a --exclude=hyde ./. ./hyde/packages/hyde/framework/src
           fi
           
       # Update the Hyde project's composer.json to load the framework from the local source

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,15 +38,19 @@ jobs:
 
       - name: Require latest framework version
         if: "github.ref == 'refs/heads/master'"
-        run: cd hyde && composer require hyde/framework:dev-master hyde/testing:dev-master
+        run: cd hyde && composer require hyde/framework:dev-master
 
       - name: Require latest development framework version
         if: "github.ref == 'refs/heads/develop'"
-        run: cd hyde && composer require hyde/framework:dev-develop hyde/testing:dev-master
+        run: cd hyde && composer require hyde/framework:dev-develop
 
       - name: Require pull request framework version
         if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
-        run: cd hyde && composer require hyde/framework:dev-${{ github.head_ref }} hyde/testing:dev-master
+        run: cd hyde && composer require hyde/framework:dev-${{ github.head_ref }}
+
+      # We also need to install the testing package
+      - name: Require latest testing package version
+        run: cd hyde && composer require hyde/testing:dev-master
 
       - name: Copy over test files
         run: cp -r ./tests/. ./hyde/tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Require latest testing package version
         run: cd hyde && composer require hyde/testing:dev-master --no-install
 
+      # Copy over the test files to the Hyde project
       - name: Copy over test files
         run: cp -r ./tests/. ./hyde/tests
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Echo GitHub ref
         run: echo ${{ github.ref }}
 
+      # First we need to clone the Hyde repository so we have a project to serve as the test runner environment
       - name: Install Hyde
         shell: bash
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Echo GitHub ref
         run: echo ${{ github.ref }}
 
-      - name: Install Hyde (master)
-        if: "github.ref == 'refs/heads/master'"
-        run: git clone -b master https://github.com/hydephp/hyde.git
-
-      - name: Install Hyde (develop)
-        if: "github.ref != 'refs/heads/master'"
-        run: git clone -b develop https://github.com/hydephp/hyde.git
+      - name: Install Hyde
+        run: |
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            git clone -b master https://github.com/hydephp/hyde.git
+          else
+            git clone -b develop https://github.com/hydephp/hyde.git
+          fi
 
       - name: Require latest framework version
         if: "github.ref == 'refs/heads/master'"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,7 @@ jobs:
         run: echo ${{ github.ref }}
 
       - name: Install Hyde
+        shell: bash
         run: |
           if [ "${{ github.ref }}" == "refs/heads/master" ]; then
             git clone -b master https://github.com/hydephp/hyde.git

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,10 +18,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: fileinfo, zip
 
       - name: Echo GitHub ref
         run: echo ${{ github.ref }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,17 +44,12 @@ jobs:
       - name: Update composer.json to load framework from local source
         run: |
           cd hyde
-          composer require hyde/testing:dev-master --no-install
           composer config repositories.framework path ./packages/hyde/framework
-          composer require hyde/framework:dev-develop --no-install
+          composer require hyde/testing:dev-master hyde/framework:dev-develop
 
       # Copy over the test files to the Hyde project
       - name: Copy over test files
         run: cp -r ./tests/. ./hyde/tests
-
-      # Now we can install the Composer dependencies
-      - name: Install Composer dependencies
-        run: cd hyde && composer install
 
       - name: Download test runner configuration
         run: cd hyde && curl https://raw.githubusercontent.com/hydephp/develop/master/packages/hyde/phpunit.xml.dist -o phpunit.xml.dist

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,6 @@ jobs:
 
       # Now, we copy the framework source code to the Hyde project
       - name: Copy over framework source code
-        shell: bash
         run: |
           mkdir -p ./hyde/packages/hyde/framework/src
           rsync -a --exclude=hyde/ ./ ./hyde/packages/hyde/framework/src

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,12 +44,9 @@ jobs:
       - name: Update composer.json to load framework from local source
         run: |
           cd hyde
+          composer require hyde/testing:dev-master --no-install
           composer config repositories.framework path ./packages/hyde/framework
           composer require hyde/framework:dev-develop --no-install
-
-      # We also need to install the testing package
-      - name: Require latest testing package version
-        run: cd hyde && composer require hyde/testing:dev-master --no-install
 
       # Copy over the test files to the Hyde project
       - name: Copy over test files

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,15 +39,15 @@ jobs:
       # Now, we copy the framework source code to the Hyde project
       - name: Copy over framework source code
         run: |
-          mkdir -p ./hyde/packages/framework/src
-          cp -r ./src/. ./hyde/packages/framework/src
-          cp ./composer.json ./hyde/packages/framework/composer.json
+          mkdir -p ./hyde/packages/hyde/framework/src
+          cp -r ./src/. ./hyde/packages/hyde/framework/src
+          cp ./composer.json ./hyde/packages/hyde/framework/composer.json
 
       # Update the Hyde project's composer.json to load the framework from the local source
       - name: Update composer.json to load framework from local source
         run: |
           cd hyde
-          composer config repositories.framework path ./packages/framework
+          composer config repositories.framework path ./packages/hyde/framework
           composer require hyde/framework:dev-develop --no-install
 
       # We also need to install the testing package

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,10 +41,10 @@ jobs:
 
           # Since we can't use rsync on Windows, we have to setup a temporary directory to copy the files to
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            mkdir ../temp
-            cp -r ./ ../temp
-            rm -rf ../temp/hyde
-            cp -r ./temp/. ./hyde/packages/hyde/framework/src
+              mkdir ../temp
+              cp -r ./ ../temp
+              rm -rf ../temp/hyde
+              cp -r ./temp/. ./hyde/packages/hyde/framework/src
           else
               rsync -a --exclude=hyde ./. ./hyde/packages/hyde/framework/src
           fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: [8.1, 8.2, 8.3]
+        php: [8.1] # Temporary change to speed up testing
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,6 +42,13 @@ jobs:
           cp -r ./src/. ./hyde/packages/framework/src
           cp ./composer.json ./hyde/packages/framework/composer.json
 
+      # Update the Hyde project's composer.json to load the framework from the local source
+        - name: Update composer.json to load framework from local source
+          run: |
+            cd hyde
+            composer config repositories.framework path ../packages/framework
+            composer require hyde/framework:dev-master
+
       # We also need to install the testing package
       - name: Require latest testing package version
         run: cd hyde && composer require hyde/testing:dev-master

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,18 +36,6 @@ jobs:
             git clone -b develop https://github.com/hydephp/hyde.git
           fi
 
-      - name: Require latest framework version
-        if: "github.ref == 'refs/heads/master'"
-        run: cd hyde && composer require hyde/framework:dev-master
-
-      - name: Require latest development framework version
-        if: "github.ref == 'refs/heads/develop'"
-        run: cd hyde && composer require hyde/framework:dev-develop
-
-      - name: Require pull request framework version
-        if: "github.ref != 'refs/heads/master' && github.ref != 'refs/heads/develop'"
-        run: cd hyde && composer require hyde/framework:dev-${{ github.head_ref }}
-
       # We also need to install the testing package
       - name: Require latest testing package version
         run: cd hyde && composer require hyde/testing:dev-master

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,7 +39,6 @@ jobs:
           mkdir -p ./hyde/packages/hyde/framework/src
           cp -r ./src/. ./hyde/packages/hyde/framework/src
           cp ./composer.json ./hyde/packages/hyde/framework/composer.json
-          ls -la ./hyde/packages/hyde/framework/src
 
       # Update the Hyde project's composer.json to load the framework from the local source
       - name: Update composer.json to load framework from local source

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Copy over test files
         run: cp -r ./tests/. ./hyde/tests
 
+      # Now we can install the Composer dependencies
+      - name: Install Composer dependencies
+        run: cd hyde && composer install
+
       - name: Download test runner configuration
         run: cd hyde && curl https://raw.githubusercontent.com/hydephp/develop/master/packages/hyde/phpunit.xml.dist -o phpunit.xml.dist
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,6 +36,12 @@ jobs:
             git clone -b develop https://github.com/hydephp/hyde.git
           fi
 
+      # Now, we copy the framework source code to the Hyde project
+      - name: Copy over framework source code
+        run: |
+          cp -r ./src/. ./hyde/packages/framework/src
+          cp ./composer.json ./hyde/packages/framework/composer.json
+
       # We also need to install the testing package
       - name: Require latest testing package version
         run: cd hyde && composer require hyde/testing:dev-master

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,6 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: fileinfo, zip
 
-      # First we need to clone the Hyde repository so we have a project to serve as the test runner environment
       - name: Install Hyde
         shell: bash
         run: |
@@ -33,7 +32,6 @@ jobs:
             git clone -b develop https://github.com/hydephp/hyde.git
           fi
 
-      # Now, we copy the framework source code to the Hyde project
       - name: Copy over framework source code
         shell: bash
         run: |
@@ -49,7 +47,6 @@ jobs:
               rsync -a --exclude=hyde ./. ./hyde/packages/hyde/framework/src
           fi
           
-      # Update the Hyde project's composer.json to load the framework from the local source
       - name: Update composer.json to load framework from local source
         run: |
           cd hyde

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,10 +35,20 @@ jobs:
 
       # Now, we copy the framework source code to the Hyde project
       - name: Copy over framework source code
+        shell: bash
         run: |
           mkdir -p ./hyde/packages/hyde/framework/src
-          rsync -a --exclude=hyde/ ./ ./hyde/packages/hyde/framework/src
 
+          # Since we can't use rsync on Windows, we have to setup a temporary directory to copy the files to
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            mkdir ../temp
+            cp -r ./ ./temp
+            rm -rf ./temp/hyde
+            cp -r ./temp/. ./hyde/packages/hyde/framework/src
+          else
+              rsync -a --exclude=hyde ./packages/framework/. ./hyde/packages/hyde/framework/src
+          fi
+          
       # Update the Hyde project's composer.json to load the framework from the local source
       - name: Update composer.json to load framework from local source
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           mkdir -p ./hyde/packages/hyde/framework/src
 
-          # Since we can't use rsync on Windows, we have to setup a temporary directory to copy the files to
+          # Since we can't use rsync on Windows, we need to copy the files to a temporary directory and then copy them back
           if [ "${{ matrix.os }}" == "windows-latest" ]; then
               mkdir ../temp
               cp -r ./ ../temp

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: fileinfo, zip
 
       - name: Echo GitHub ref
         run: echo ${{ github.ref }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,7 +44,7 @@ jobs:
               mkdir ../temp
               cp -r ./ ../temp
               rm -rf ../temp/hyde
-              cp -r ./temp/. ./hyde/packages/hyde/framework/src
+              cp -r ../temp/. ./hyde/packages/hyde/framework/src
           else
               rsync -a --exclude=hyde ./. ./hyde/packages/hyde/framework/src
           fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,6 +39,7 @@ jobs:
       # Now, we copy the framework source code to the Hyde project
       - name: Copy over framework source code
         run: |
+          mkdir -p ./hyde/packages/framework/src
           cp -r ./src/. ./hyde/packages/framework/src
           cp ./composer.json ./hyde/packages/framework/composer.json
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Update composer.json to load framework from local source
         run: |
           cd hyde
-          composer config repositories.framework path ../packages/framework
+          composer config repositories.framework path ./packages/framework
           composer require hyde/framework:dev-master
 
       # We also need to install the testing package

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: [8.1] # Temporary change to speed up testing
+        php: [8.1, 8.2, 8.3]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           cd hyde
           composer config repositories.framework path ./packages/framework
-          composer require hyde/framework:dev-master
+          composer require hyde/framework:dev-develop
 
       # We also need to install the testing package
       - name: Require latest testing package version

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,5 @@
 name: Framework Tests (Matrix)
+
 on:
   push:
     branches: ["master", "develop"]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,11 +43,11 @@ jobs:
           cp ./composer.json ./hyde/packages/framework/composer.json
 
       # Update the Hyde project's composer.json to load the framework from the local source
-        - name: Update composer.json to load framework from local source
-          run: |
-            cd hyde
-            composer config repositories.framework path ../packages/framework
-            composer require hyde/framework:dev-master
+      - name: Update composer.json to load framework from local source
+        run: |
+          cd hyde
+          composer config repositories.framework path ../packages/framework
+          composer require hyde/framework:dev-master
 
       # We also need to install the testing package
       - name: Require latest testing package version

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Copy over framework source code
         run: |
           mkdir -p ./hyde/packages/hyde/framework/src
-          cp -r ./src/. ./hyde/packages/hyde/framework/src
-          cp ./composer.json ./hyde/packages/hyde/framework/composer.json
+          rsync -a --exclude=hyde/ ./ ./hyde/packages/hyde/framework/src
 
       # Update the Hyde project's composer.json to load the framework from the local source
       - name: Update composer.json to load framework from local source
@@ -46,10 +45,6 @@ jobs:
           cd hyde
           composer config repositories.framework path ./packages/hyde/framework
           composer require hyde/testing:dev-master hyde/framework:dev-develop
-
-      # Copy over the test files to the Hyde project
-      - name: Copy over test files
-        run: cp -r ./tests/. ./hyde/tests
 
       - name: Download test runner configuration
         run: cd hyde && curl https://raw.githubusercontent.com/hydephp/develop/master/packages/hyde/phpunit.xml.dist -o phpunit.xml.dist

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,11 +48,11 @@ jobs:
         run: |
           cd hyde
           composer config repositories.framework path ./packages/framework
-          composer require hyde/framework:dev-develop
+          composer require hyde/framework:dev-develop --no-install
 
       # We also need to install the testing package
       - name: Require latest testing package version
-        run: cd hyde && composer require hyde/testing:dev-master
+        run: cd hyde && composer require hyde/testing:dev-master --no-install
 
       - name: Copy over test files
         run: cp -r ./tests/. ./hyde/tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,6 +39,7 @@ jobs:
           mkdir -p ./hyde/packages/hyde/framework/src
           cp -r ./src/. ./hyde/packages/hyde/framework/src
           cp ./composer.json ./hyde/packages/hyde/framework/composer.json
+          ls -la ./hyde/packages/hyde/framework/src
 
       # Update the Hyde project's composer.json to load the framework from the local source
       - name: Update composer.json to load framework from local source

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,9 +23,6 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: fileinfo, zip
 
-      - name: Echo GitHub ref
-        run: echo ${{ github.ref }}
-
       # First we need to clone the Hyde repository so we have a project to serve as the test runner environment
       - name: Install Hyde
         shell: bash


### PR DESCRIPTION
Improve the test environment setup process by using a local Composer package path instead of trying to require the right branch name though GitHub. This is both less complex, and should make so that the tests can also run in forks. May also be a tiny bit faster due to less network calls.