### PR TITLE
Add `webp` to the list of default media extensions

### DIFF
--- a/src/Support/Filesystem/MediaFile.php
+++ b/src/Support/Filesystem/MediaFile.php
@@ -27,7 +27,7 @@ use function glob;
 class MediaFile extends ProjectFile
 {
     /** @var array<string> The default extensions for media types */
-    final public const EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'gif', 'ico', 'css', 'js'];
+    final public const EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'webp', 'gif', 'ico', 'css', 'js'];
 
     /** @return array<string, \Hyde\Support\Filesystem\MediaFile> The array keys are the filenames relative to the _media/ directory */
     public static function all(): array


### PR DESCRIPTION
This allows `.webp` images to be automatically supported in builds.