### PR TITLE
Deprecate `Hyde::mediaLink` being replaced by `Hyde::asset()` in v2

### DIFF
--- a/src/Foundation/Concerns/ForwardsHyperlinks.php
+++ b/src/Foundation/Concerns/ForwardsHyperlinks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyde\Foundation\Concerns;
 
 use Hyde\Support\Models\Route;
+use JetBrains\PhpStorm\Deprecated;
 
 /**
  * @internal Single-use trait for the HydeKernel class.
@@ -23,8 +24,14 @@ trait ForwardsHyperlinks
         return $this->hyperlinks->relativeLink($destination);
     }
 
+    /**
+     * @deprecated This method will be removed in v2.0. Please use `asset()` instead.
+     */
+    #[Deprecated(reason: 'Use `asset` method instead.', replacement: '%class%::asset(%parameter0%)')]
     public function mediaLink(string $destination, bool $validate = false): string
     {
+        trigger_deprecation('hyde/framework', '1.8.0', 'The %s() method is deprecated, use %s() instead.', __METHOD__, 'asset');
+
         return $this->hyperlinks->mediaLink($destination, $validate);
     }
 

--- a/src/Foundation/Kernel/Hyperlinks.php
+++ b/src/Foundation/Kernel/Hyperlinks.php
@@ -7,6 +7,7 @@ namespace Hyde\Foundation\Kernel;
 use Hyde\Facades\Config;
 use Hyde\Support\Models\Route;
 use Hyde\Foundation\HydeKernel;
+use JetBrains\PhpStorm\Deprecated;
 use Hyde\Framework\Exceptions\BaseUrlNotSetException;
 use Hyde\Framework\Exceptions\FileNotFoundException;
 use Illuminate\Support\Str;
@@ -92,7 +93,10 @@ class Hyperlinks
      *
      * An exception will be thrown if the file does not exist in the _media directory,
      * and the second argument is set to true.
+     *
+     * @deprecated This method will be removed in v2.0. Please use `asset()` instead.
      */
+    #[Deprecated(reason: 'Use `asset` method instead.', replacement: '%class%->asset(%parameter0%)')]
     public function mediaLink(string $destination, bool $validate = false): string
     {
         if ($validate && ! file_exists($sourcePath = "{$this->kernel->getMediaDirectory()}/$destination")) {


### PR DESCRIPTION
Merges pull request https://github.com/hydephp/develop/pull/1993