### PR TITLE
Improve the `Serializable` trait to support automatic serialization

### DIFF
--- a/src/Support/Concerns/Serializable.php
+++ b/src/Support/Concerns/Serializable.php
@@ -14,8 +14,13 @@ use function collect;
  */
 trait Serializable
 {
-    /** @inheritDoc */
-    abstract public function toArray(): array;
+    /** Default implementation to dynamically serialize all public properties. Can be overridden for increased control. */
+    public function toArray(): array
+    {
+        // Calling the function from a different scope means we only get the public properties.
+
+        return get_object_vars(...)->__invoke($this);
+    }
 
     /** Recursively serialize Arrayables */
     public function arraySerialize(): array

--- a/src/Support/Concerns/Serializable.php
+++ b/src/Support/Concerns/Serializable.php
@@ -17,9 +17,7 @@ trait Serializable
     /** Default implementation to dynamically serialize all public properties. Can be overridden for increased control. */
     public function toArray(): array
     {
-        // Calling the function from a different scope means we only get the public properties.
-
-        return get_object_vars(...)->__invoke($this);
+        return $this->automaticallySerialize();
     }
 
     /** Recursively serialize Arrayables */
@@ -38,5 +36,13 @@ trait Serializable
     public function toJson($options = 0): string
     {
         return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /** Automatically serialize all public properties. */
+    protected function automaticallySerialize(): array
+    {
+        // Calling the function from a different scope means we only get the public properties.
+
+        return get_object_vars(...)->__invoke($this);
     }
 }

--- a/tests/Unit/SerializableTest.php
+++ b/tests/Unit/SerializableTest.php
@@ -53,6 +53,15 @@ class SerializableTest extends UnitTestCase
     {
         $this->assertSame('{"foo":"bar","arrayable":{"foo":"bar"}}', (new SerializableTestClassWithArrayable)->toJson());
     }
+
+    public function testAutomaticallySerialization()
+    {
+        $this->assertSame([
+            'foo' => 'foo',
+            'bar' => 'bar',
+            'baz' => ['baz' => 'baz'],
+        ], (new AutomaticallySerializableTestClass)->toArray());
+    }
 }
 
 class SerializableTestClass implements SerializableContract
@@ -80,5 +89,31 @@ class ArrayableTestClass implements Arrayable
     public function toArray(): array
     {
         return ['foo' => 'bar'];
+    }
+}
+
+class AutomaticallySerializableTestClass implements SerializableContract
+{
+    use Serializable;
+
+    public string $foo;
+    public string $bar;
+    public array $baz;
+
+    public string $uninitialized;
+
+    protected string $hidden;
+    private string $private;
+
+    public static string $static;
+
+    public function __construct()
+    {
+        $this->foo = 'foo';
+        $this->bar = 'bar';
+        $this->baz = ['baz' => 'baz'];
+        $this->hidden = 'hidden';
+        $this->private = 'private';
+        static::$static = 'static';
     }
 }


### PR DESCRIPTION
Merges the following pull requests:
- Update the `Serializable` trait to provide a default automatic `toArray` method in https://github.com/hydephp/develop/pull/1791
- Extract helper method for automatic serialization in https://github.com/hydephp/develop/pull/1793