### PR TITLE
 Fix search index not trimming numerical ordering prefixes

### DIFF
--- a/src/Framework/Actions/GeneratesDocumentationSearchIndex.php
+++ b/src/Framework/Actions/GeneratesDocumentationSearchIndex.php
@@ -55,10 +55,10 @@ class GeneratesDocumentationSearchIndex
     protected function generatePageEntry(DocumentationPage $page): array
     {
         return [
-            'slug' => basename($page->identifier),
+            'slug' => basename($page->routeKey),
             'title' => $page->title,
             'content' => trim($this->getSearchContentForDocument($page)),
-            'destination' => $this->formatDestination(basename($page->identifier)),
+            'destination' => $this->formatDestination(basename($page->routeKey)),
         ];
     }
 

--- a/src/Framework/Factories/HydePageDataFactory.php
+++ b/src/Framework/Factories/HydePageDataFactory.php
@@ -10,6 +10,7 @@ use Hyde\Markdown\Models\FrontMatter;
 use Hyde\Markdown\Contracts\FrontMatter\PageSchema;
 use Hyde\Framework\Factories\Concerns\CoreDataObject;
 use Hyde\Framework\Features\Navigation\NavigationData;
+use Hyde\Framework\Features\Navigation\NumericalPageOrderingHelper;
 
 use function basename;
 use function dirname;
@@ -68,7 +69,18 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
         return $this->getMatter('title')
             ?? $this->findTitleFromMarkdownHeadings()
             ?? $this->findTitleFromParentIdentifier()
-            ?? Hyde::makeTitle(basename($this->identifier));
+            ?? Hyde::makeTitle($this->getCleanBasename());
+    }
+
+    private function getCleanBasename(): string
+    {
+        $basename = basename($this->identifier);
+
+        if (NumericalPageOrderingHelper::hasNumericalPrefix($basename)) {
+            return NumericalPageOrderingHelper::splitNumericPrefix($basename)[1];
+        }
+
+        return $basename;
     }
 
     private function findTitleFromMarkdownHeadings(): ?string
@@ -87,7 +99,13 @@ class HydePageDataFactory extends Concerns\PageDataFactory implements PageSchema
     private function findTitleFromParentIdentifier(): ?string
     {
         if (str_contains($this->identifier, '/') && str_ends_with($this->identifier, '/index')) {
-            return Hyde::makeTitle(basename(dirname($this->identifier)));
+            $parentBasename = basename(dirname($this->identifier));
+
+            if (NumericalPageOrderingHelper::hasNumericalPrefix($parentBasename)) {
+                $parentBasename = NumericalPageOrderingHelper::splitNumericPrefix($parentBasename)[1];
+            }
+
+            return Hyde::makeTitle($parentBasename);
         }
 
         return null;

--- a/tests/Feature/Services/DocumentationSearchServiceTest.php
+++ b/tests/Feature/Services/DocumentationSearchServiceTest.php
@@ -114,6 +114,31 @@ class DocumentationSearchServiceTest extends UnitTestCase
         );
     }
 
+    public function testNumericPrefixesAreStrippedFromSearchResults()
+    {
+        $this->file('_docs/01-foo.md');
+
+        $this->assertSame([[
+            'slug' => 'foo',
+            'title' => 'Foo',
+            'content' => '',
+            'destination' => 'foo.html',
+        ]], $this->getArray());
+    }
+
+    public function testNumericPrefixesAreRemovedFromNestedSearchResults()
+    {
+        $this->directory(Hyde::path('_docs/01-category'));
+        $this->file('_docs/01-category/02-item-name.md');
+
+        $result = $this->getArray()[0];
+
+        $this->assertSame('item-name', $result['slug']);
+        $this->assertSame('item-name.html', $result['destination']);
+        $this->assertStringNotContainsString('02-', json_encode($result));
+        $this->assertStringNotContainsString('01-', json_encode($result));
+    }
+
     protected function getArray(): array
     {
         return json_decode(GeneratesDocumentationSearchIndex::handle(), true);

--- a/tests/Unit/HydePageDataFactoryTest.php
+++ b/tests/Unit/HydePageDataFactoryTest.php
@@ -72,6 +72,26 @@ class HydePageDataFactoryTest extends UnitTestCase
         $this->assertInstanceOf(NavigationData::class, $this->factory()->toArray()['navigation']);
     }
 
+    public function testTitleStripsNumericalPrefixFromBasename()
+    {
+        $this->assertSame('Foo', $this->factoryFromPage(new MarkdownPage('01-foo'))->toArray()['title']);
+    }
+
+    public function testTitleStripsNumericalPrefixFromNestedBasename()
+    {
+        $this->assertSame('Bar', $this->factoryFromPage(new MarkdownPage('foo/02-bar'))->toArray()['title']);
+    }
+
+    public function testIndexPageTitleStripsNumericalPrefixFromParentIdentifierBasename()
+    {
+        $this->assertSame('Foo', $this->factoryFromPage(new MarkdownPage('01-foo/index'))->toArray()['title']);
+    }
+
+    public function testIndexPageTitleStripsNumericalPrefixFromNestedParentIdentifierBasename()
+    {
+        $this->assertSame('Bar', $this->factoryFromPage(new MarkdownPage('foo/02-bar/index'))->toArray()['title']);
+    }
+
     protected function factory(array $data = []): HydePageDataFactory
     {
         return $this->factoryFromPage(new InMemoryPage('', $data));


### PR DESCRIPTION
Merge pull request https://github.com/hydephp/develop/pull/2408 from hydephp/fix-search-index-not-trimming-numerical-ordering-prefixes

Fix search index not trimming numerical ordering prefixes https://github.com/hydephp/develop/commit/95cee50f740bebe63c8dab43e15aef5e8fe84971