### PR TITLE
Fix documentation links not using the v2 version links

### DIFF
--- a/config/docs.php
+++ b/config/docs.php
@@ -94,7 +94,7 @@ return [
     | Collaborative Source Editing Location
     |--------------------------------------------------------------------------
     |
-    | @see https://hydephp.com/docs/1.x/documentation-pages#automatic-edit-page-button
+    | @see https://hydephp.com/docs/2.x/documentation-pages#automatic-edit-page-button
     |
     | By adding a base URL here, Hyde will use it to create "edit source" links
     | to your documentation pages. Hyde expects this to be a GitHub path, but
@@ -118,7 +118,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | Hyde comes with an easy to use search feature for documentation pages.
-    | @see https://hydephp.com/docs/1.x/documentation-pages#search-feature
+    | @see https://hydephp.com/docs/2.x/documentation-pages#search-feature
     |
     */
 

--- a/config/hyde.php
+++ b/config/hyde.php
@@ -313,7 +313,7 @@ return [
     | You can disable it completely by changing the setting to `false`.
     |
     | To read about the many configuration options here, visit:
-    | https://hydephp.com/docs/1.x/customization#footer
+    | https://hydephp.com/docs/2.x/customization#footer
     |
     */
 

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -75,7 +75,7 @@ return [
     | arbitrary PHP to run. But if your Markdown is trusted, try it out!
     |
     | To see the syntax and usage, see the documentation:
-    | @see https://hydephp.com/docs/1.x/advanced-markdown#blade-support
+    | @see https://hydephp.com/docs/2.x/advanced-markdown#blade-support
     |
     */
 

--- a/resources/views/homepages/welcome.blade.php
+++ b/resources/views/homepages/welcome.blade.php
@@ -65,7 +65,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://hydephp.com/docs/1.x/getting-started" class="uppercase font-bold text-sm flex text-center m-2 mx-3">
+                            <a href="https://hydephp.com/docs/2.x/getting-started" class="uppercase font-bold text-sm flex text-center m-2 mx-3">
                                 Getting Started
                             </a>
                         </li>

--- a/resources/views/layouts/styles.blade.php
+++ b/resources/views/layouts/styles.blade.php
@@ -16,7 +16,7 @@
     @if(config('hyde.use_play_cdn', false))
         <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
         <script>tailwind.config = { {!! HydeFront::injectTailwindConfig() !!} }</script>
-        <script>console.warn('The HydePHP TailwindCSS Play CDN is enabled. This is for development purposes only and should not be used in production.', 'See https://hydephp.com/docs/1.x/managing-assets');</script>
+        <script>console.warn('The HydePHP TailwindCSS Play CDN is enabled. This is for development purposes only and should not be used in production.', 'See https://hydephp.com/docs/2.x/managing-assets');</script>
     @endif
 @endif
 

--- a/src/Facades/Author.php
+++ b/src/Facades/Author.php
@@ -21,7 +21,7 @@ class Author
      *
      * The returned array will then be used by the framework to create a new PostAuthor instance.
      *
-     * @see https://hydephp.com/docs/1.x/customization#authors
+     * @see https://hydephp.com/docs/2.x/customization#authors
      *
      * @param  string|null  $name  The optional display name of the author, leave blank to use the username.
      * @param  string|null  $website  The author's optional website URL. Website, Twitter, etc.

--- a/src/Foundation/Concerns/HydeExtension.php
+++ b/src/Foundation/Concerns/HydeExtension.php
@@ -19,7 +19,7 @@ use Hyde\Foundation\Kernel\RouteCollection;
  * Before creating your extension, it will certainly be helpful if you first become familiar
  * with the basic internal architecture of HydePHP, as well as how the auto-discovery system functions.
  *
- * @link https://hydephp.com/docs/1.x/core-concepts
+ * @link https://hydephp.com/docs/2.x/core-concepts
  *
  * It's important that your class is registered before the HydeKernel boots.
  * An excellent place for this is the 'register' method of your extensions service provider,

--- a/src/Pages/BladePage.php
+++ b/src/Pages/BladePage.php
@@ -14,8 +14,8 @@ use Illuminate\Support\Facades\View;
  * Blade pages are stored in the _pages directory and using the .blade.php extension.
  * They will be compiled using the Laravel Blade engine to the _site/ directory.
  *
- * @see https://hydephp.com/docs/1.x/static-pages#creating-blade-pages
- * @see https://laravel.com/docs/1.x/blade
+ * @see https://hydephp.com/docs/2.x/static-pages#creating-blade-pages
+ * @see https://laravel.com/docs/2.x/blade
  */
 class BladePage extends HydePage
 {

--- a/src/Pages/DocumentationPage.php
+++ b/src/Pages/DocumentationPage.php
@@ -20,7 +20,7 @@ use function basename;
  * Documentation pages are stored in the _docs directory and using the .md extension.
  * The Markdown will be compiled to HTML using the documentation page layout to the _site/docs/ directory.
  *
- * @see https://hydephp.com/docs/1.x/documentation-pages
+ * @see https://hydephp.com/docs/2.x/documentation-pages
  */
 class DocumentationPage extends BaseMarkdownPage
 {
@@ -38,7 +38,7 @@ class DocumentationPage extends BaseMarkdownPage
         return unslash(static::baseRouteKey().'/index');
     }
 
-    /** @see https://hydephp.com/docs/1.x/documentation-pages#automatic-edit-page-button */
+    /** @see https://hydephp.com/docs/2.x/documentation-pages#automatic-edit-page-button */
     public function getOnlineSourcePath(): string|false
     {
         if (Config::getNullableString('docs.source_file_location_base') === null) {

--- a/src/Pages/HtmlPage.php
+++ b/src/Pages/HtmlPage.php
@@ -12,7 +12,7 @@ use Hyde\Pages\Concerns\HydePage;
  * Html pages are stored in the _pages directory and using the .html extension.
  * These pages will be copied exactly as they are to the _site/ directory.
  *
- * @see https://hydephp.com/docs/1.x/static-pages#bonus-creating-html-pages
+ * @see https://hydephp.com/docs/2.x/static-pages#bonus-creating-html-pages
  */
 class HtmlPage extends HydePage
 {

--- a/src/Pages/MarkdownPage.php
+++ b/src/Pages/MarkdownPage.php
@@ -12,7 +12,7 @@ use Hyde\Pages\Concerns\BaseMarkdownPage;
  * Markdown pages are stored in the _pages directory and using the .md extension.
  * The Markdown will be compiled to HTML using a minimalistic layout to the _site/ directory.
  *
- * @see https://hydephp.com/docs/1.x/static-pages#creating-markdown-pages
+ * @see https://hydephp.com/docs/2.x/static-pages#creating-markdown-pages
  */
 class MarkdownPage extends BaseMarkdownPage
 {

--- a/src/Pages/MarkdownPost.php
+++ b/src/Pages/MarkdownPost.php
@@ -19,7 +19,7 @@ use function array_merge;
  * Markdown posts are stored in the _posts directory and using the .md extension.
  * The Markdown will be compiled to HTML using the blog post layout to the _site/posts/ directory.
  *
- * @see https://hydephp.com/docs/1.x/blog-posts
+ * @see https://hydephp.com/docs/2.x/blog-posts
  */
 class MarkdownPost extends BaseMarkdownPage implements BlogPostSchema
 {


### PR DESCRIPTION
Merges pull request [hydephp/develop#2503](https://github.com/hydephp/develop/pull/2503) into the framework `master` branch.

Original Develop commit: [0066846cd7f1a02203566be75d303a087f46c930](https://github.com/hydephp/develop/commit/0066846cd7f1a02203566be75d303a087f46c930)

Framework source commit: [094e5be0842ec724923456dd695cb54103aba622](https://github.com/hydephp/framework/commit/094e5be0842ec724923456dd695cb54103aba622)
