### PR TITLE
Internal: Update endpoint for the monorepo CI server

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -62,5 +62,5 @@ jobs:
       - name: Ping statistics server with test results
         run: |
           cd runner
-          curl https://raw.githubusercontent.com/hydephp/develop/6e9d17f31879f4ccda13a3fec4029c9663bccec0/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
+          curl https://raw.githubusercontent.com/hydephp/develop/1bab6fc070a1b636cb4b69e44a9bf7fea1286c0f/monorepo/scripts/ping-openanalytics-testrunner.php -o ping.php
           php ping.php "Framework CI Matrix" ${{ secrets.OPENANALYTICS_TOKEN }}


### PR DESCRIPTION
Merges pull request [hydephp/develop#2498](https://github.com/hydephp/develop/pull/2498) into the framework `master` branch.

Original Develop commit: [a214d3acf05e998364c391d13be5f44b578919ff](https://github.com/hydephp/develop/commit/a214d3acf05e998364c391d13be5f44b578919ff)

Framework source commit: [7d75d85cc416dd8d593f02820d571efd2ed4805e](https://github.com/hydephp/framework/commit/7d75d85cc416dd8d593f02820d571efd2ed4805e)
